### PR TITLE
bug/unexpectedly-high-amount-of-requests-before-global-timeout

### DIFF
--- a/request/do.go
+++ b/request/do.go
@@ -68,6 +68,7 @@ func Do(ctx context.Context, requests, concurrency int, url string, timeout time
 				defer release(sem, &wg)
 				rec <- doRequest(url, timeout)
 			}()
+			wg.Wait()
 		}
 	}()
 


### PR DESCRIPTION
## Description

Bug:
The runner seems to do one too many request compared to what is asked.
See [this comment](https://github.com/benchttp/runner/pull/8#discussion_r790142374).

## Changes
Added a wg.Wait() at the end of the for loop seemed to correct the bug.

## Notes
It seems that a new iteration in the for loop had begun before the previous one has ended.

For example, changing the code in do.go to:
```
go func() {
		defer func() {
			wg.Wait()
			close(rec)
		}()
		for i := 0; i < requests; i++ {
			fmt.Println(fmt.Sprintf("Entering loop with i=%d", i))
			select {
			case <-ctx.Done():
				return
			default:
			}
			acquire(sem, &wg)
			go func(i int) {
				fmt.Println(fmt.Sprintf("Entering go func() with i=%d", i))
				defer release(sem, &wg)
				rec <- doRequest(url, timeout)
			}(i)
		}
	}()
```
We got this output:
```
Entering loop with i=0
Entering loop with i=1
Entering go func() with i=0
Entering loop with i=2
Entering go func() with i=1
Entering loop with i=3
Entering go func() with i=2
3
```