### PR TITLE
feat: implement request tracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ CLI options:
   -requests int
         Maximum number of requests to run, 0 means no limit (default 0)
   -timeout duration
-        Timeout for each http request (default 10s)
+        Timeout for each HTTP request (default 10s)
 ```
 
 ## Example and ouput

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -22,7 +22,7 @@ var (
 	url           string
 	concurrency   int           // Number of connections to run concurrently
 	requests      int           // Number of requests to run, use duration as exit condition if omitted.
-	timeout       time.Duration // Timeout for each http request
+	timeout       time.Duration // Timeout for each HTTP request
 	globalTimeout time.Duration // Duration of test
 )
 
@@ -37,7 +37,7 @@ func parseArgs() {
 	flag.StringVar(&url, "url", "", "Target URL to request")
 	flag.IntVar(&concurrency, "concurrency", 0, "Number of connections to run concurrently")
 	flag.IntVar(&requests, "requests", 0, "Number of requests to run, use duration as exit condition if omitted")
-	flag.DurationVar(&timeout, "timeout", 0, "Timeout for each http request")
+	flag.DurationVar(&timeout, "timeout", 0, "Timeout for each HTTP request")
 	flag.DurationVar(&globalTimeout, "globalTimeout", 0, "Duration of test")
 	flag.Parse()
 }

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -64,7 +64,7 @@ type Record struct {
 	Time   time.Duration `json:"time"`
 	Code   int           `json:"code"`
 	Bytes  int           `json:"bytes"`
-	Error  error         `json:"error"`
+	Error  error         `json:"error,omitempty"`
 	Events []Event       `json:"events"`
 }
 

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -16,17 +16,24 @@ type Requester struct {
 
 	config config.Config
 	client http.Client
+	tracer *tracer
 }
 
 // New returns a Requester configured with specified Options.
 func New(cfg config.Config) *Requester {
+	tracer := newTracer()
 	return &Requester{
 		records: make(chan Record, cfg.RunnerOptions.Requests),
 		config:  cfg,
+		tracer:  tracer,
 		client: http.Client{
-			// Timeout includes connection time, any redirects, and reading the response body.
+			// Timeout includes connection time, any redirects, and reading
+			// the response body.
 			// We may want exclude reading the response body in our benchmark tool.
 			Timeout: cfg.Request.Timeout,
+
+			// tracer keeps track of all events of the current request.
+			Transport: tracer,
 		},
 	}
 }
@@ -54,10 +61,11 @@ func (r *Requester) Run() Report {
 // response body, invalidating the entire response, as it is not a remote
 // server error.
 type Record struct {
-	Time  time.Duration `json:"time"`
-	Code  int           `json:"code"`
-	Bytes int           `json:"bytes"`
-	Error error         `json:"error"`
+	Time   time.Duration `json:"time"`
+	Code   int           `json:"code"`
+	Bytes  int           `json:"bytes"`
+	Error  error         `json:"error"`
+	Events []Event       `json:"events"`
 }
 
 func (r *Requester) record() {
@@ -83,8 +91,9 @@ func (r *Requester) record() {
 	}
 
 	r.records <- Record{
-		Code:  resp.StatusCode,
-		Time:  time.Since(sent),
-		Bytes: len(body),
+		Code:   resp.StatusCode,
+		Time:   time.Since(sent),
+		Bytes:  len(body),
+		Events: r.tracer.events,
 	}
 }

--- a/requester/tracer.go
+++ b/requester/tracer.go
@@ -7,14 +7,14 @@ import (
 	"time"
 )
 
-// Event is a stage of an outgoing http request associated with a timestamp.
+// Event is a stage of an outgoing HTTP request associated with a timestamp.
 type Event struct {
 	Name string        `json:"name"`
 	Time time.Duration `json:"time"`
 }
 
 // tracer is a http.RoundTripper to be used as a http.Transport
-// that records the events of an outgoing http request.
+// that records the events of an outgoing HTTP request.
 type tracer struct {
 	start  time.Time
 	events []Event
@@ -29,7 +29,7 @@ func (p *tracer) RoundTrip(r *http.Request) (*http.Response, error) {
 }
 
 // trace returns a http.ClientTrace that timestamps and records the events
-// of an outgoint http requests.
+// of an outgoing HTTP request.
 func (p *tracer) trace() *httptrace.ClientTrace {
 	return &httptrace.ClientTrace{
 		GetConn: func(string) {

--- a/requester/tracer.go
+++ b/requester/tracer.go
@@ -1,0 +1,85 @@
+package requester
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptrace"
+	"time"
+)
+
+// Event is a stage of an outgoing http request associated with a timestamp.
+type Event struct {
+	Name string        `json:"name"`
+	Time time.Duration `json:"time"`
+}
+
+// tracer is a http.RoundTripper to be used as a http.Transport
+// that records the events of an outgoing http request.
+type tracer struct {
+	start  time.Time
+	events []Event
+}
+
+// RoundTrip implements http.RoundTripper. It attaches the client trace
+// to the request context and calls http.DefaultTransport.RoundTrip
+// with the new created request.
+func (p *tracer) RoundTrip(r *http.Request) (*http.Response, error) {
+	ctx := httptrace.WithClientTrace(r.Context(), p.trace())
+	return http.DefaultTransport.RoundTrip(r.WithContext(ctx))
+}
+
+// trace returns a http.ClientTrace that timestamps and records the events
+// of an outgoint http requests.
+func (p *tracer) trace() *httptrace.ClientTrace {
+	return &httptrace.ClientTrace{
+		GetConn: func(string) {
+			p.start = time.Now()
+			p.addEvent("GetConn")
+		},
+		DNSStart: func(httptrace.DNSStartInfo) {
+			p.addEvent("DNSStart")
+		},
+		DNSDone: func(httptrace.DNSDoneInfo) {
+			p.addEvent("DNSDone")
+		},
+		ConnectStart: func(string, string) {
+			p.addEvent("ConnectStart")
+		},
+		ConnectDone: func(string, string, error) {
+			p.addEvent("ConnectDone")
+		},
+		GotConn: func(httptrace.GotConnInfo) {
+			p.addEvent("GotConn")
+		},
+		TLSHandshakeStart: func() {
+			p.addEvent("TLSHandshakeStart")
+		},
+		TLSHandshakeDone: func(tls.ConnectionState, error) {
+			p.addEvent("TLSHandshakeDone")
+		},
+
+		WroteHeaders: func() {
+			p.addEvent("WroteHeaders")
+		},
+		WroteRequest: func(httptrace.WroteRequestInfo) {
+			p.addEvent("WroteRequest")
+		},
+		GotFirstResponseByte: func() {
+			p.addEvent("GotFirstResponseByte")
+		},
+		PutIdleConn: func(error) {
+			p.addEvent("PutIdleConn")
+		},
+	}
+}
+
+// addEvent timestamps and appends and event to the tracer's events slice.
+func (p *tracer) addEvent(name string) {
+	p.events = append(p.events, Event{Name: name, Time: time.Since(p.start)})
+}
+
+// newTracer returns an initialized tracer.
+func newTracer() *tracer {
+	p := &tracer{events: make([]Event, 0, 20)}
+	return p
+}

--- a/requester/tracer_internal_test.go
+++ b/requester/tracer_internal_test.go
@@ -1,0 +1,55 @@
+package requester
+
+import (
+	"crypto/tls"
+	"net/http/httptrace"
+	"testing"
+)
+
+func TestTracer(t *testing.T) {
+	t.Run("append events on trace hooks", func(t *testing.T) {
+		tracer := newTracer()
+		trace := tracer.trace()
+
+		trace.GetConn("")
+		trace.DNSStart(httptrace.DNSStartInfo{})
+		trace.DNSDone(httptrace.DNSDoneInfo{})
+		trace.ConnectStart("", "")
+		trace.ConnectDone("", "", nil)
+		trace.GotConn(httptrace.GotConnInfo{})
+		trace.TLSHandshakeStart()
+		trace.TLSHandshakeDone(tls.ConnectionState{}, nil)
+		trace.WroteHeaders()
+		trace.WroteRequest(httptrace.WroteRequestInfo{})
+		trace.GotFirstResponseByte()
+		trace.PutIdleConn(nil)
+
+		expEventNames := []string{
+			"GetConn", "DNSStart", "DNSDone", "ConnectStart", "ConnectDone",
+			"GotConn", "TLSHandshakeStart", "TLSHandshakeDone", "WroteHeaders",
+			"WroteRequest", "GotFirstResponseByte", "PutIdleConn",
+		}
+		gotEvents := tracer.events
+
+		if len(gotEvents) != len(expEventNames) {
+			t.Errorf("missing request events:\nexp %v\n got %v", expEventNames, gotEvents)
+		}
+
+		for i, gotEvent := range gotEvents {
+			// check event names
+			if gotName, expName := gotEvent.Name, expEventNames[i]; gotName != expName {
+				t.Errorf("unexpected appended event: exp %s, got %s", expName, gotName)
+			}
+
+			// check timestamps
+			if i == 0 {
+				continue
+			}
+			if prev := gotEvents[i-1]; gotEvent.Time <= prev.Time {
+				t.Error("unexpect event time, should be incremental")
+			}
+		}
+
+		t.Log(tracer.events)
+	})
+}


### PR DESCRIPTION
<!-- IMPORTANT: Don't forget to link the issue(s) once the PR created! -->

## Description

Implement and add profiling features to the request benchmarks.

Instead of measuring the total duration only, we now have access to a timestamp for each step of an http request.
This will allow for more insightful data for the user.

### Example

- Local request (`http`)
  ```
  ./bin/benchttp -requests 1 -url "http://localhost:9999"
  ```
  
  <details>
  <summary>Output</summary>
  <pre>
  [
    {
      "Cost": 0,
      "Code": 200,
      "Bytes": 0,
      "Error": null,
      "Profile": [
        {
          "Name": "GetConn",
          "Time": 70
        },
        {
          "Name": "DNSStart",
          "Time": 38155
        },
        {
          "Name": "DNSDone",
          "Time": 836820
        },
        {
          "Name": "ConnectStart",
          "Time": 866851
        },
        {
          "Name": "ConnectDone",
          "Time": 1072322
        },
        {
          "Name": "ConnectStart",
          "Time": 1125989
        },
        {
          "Name": "ConnectDone",
          "Time": 1257758
        },
        {
          "Name": "GotConn",
          "Time": 1290506
        },
        {
          "Name": "WroteHeaders",
          "Time": 1358900
        },
        {
          "Name": "WroteRequest",
          "Time": 1361062
        },
        {
          "Name": "GotFirstResponseByte",
          "Time": 1473155
        },
        {
          "Name": "PutIdleConn",
          "Time": 1528966
        }
      ]
    }
  ]
  </pre>
  </details>

- Remote request (`https`)
  ```
  ./bin/benchttp -requests 1 -url "https://example.com"
  ```
  
  <details>
  <summary>Output</summary>
  <pre>
  [
    {
      "Cost": 0,
      "Code": 200,
      "Bytes": 1256,
      "Error": null,
      "Profile": [
        {
          "Name": "GetConn",
          "Time": 74
        },
        {
          "Name": "DNSStart",
          "Time": 42508
        },
        {
          "Name": "DNSDone",
          "Time": 10587412
        },
        {
          "Name": "ConnectStart",
          "Time": 10655260
        },
        {
          "Name": "ConnectDone",
          "Time": 89404642
        },
        {
          "Name": "TLSHandshakeStart",
          "Time": 89554213
        },
        {
          "Name": "TLSHandshakeDone",
          "Time": 414801212
        },
        {
          "Name": "GotConn",
          "Time": 415041317
        },
        {
          "Name": "WroteHeaders",
          "Time": 415092642
        },
        {
          "Name": "WroteRequest",
          "Time": 415092837
        },
        {
          "Name": "GotFirstResponseByte",
          "Time": 497572965
        }
      ]
    }
  ]
  </pre>

<!--
    Describe briefly what this PR does, if the issue description is not enough.
    Add any information that could be relevant for the reviewers.
-->

## Changes

<!-- Optional: mention here indirect changes impacted by the PR -->

## Notes

<!-- Optional: additional notes than can help understanding the implementation -->
