### PR TITLE
fix: do not ignore concurrency from config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ test:
 
 # Build
 
-.PHONY: Build
+.PHONY: build
 build:
 	@go build -v -o ./bin/benchttp ./cmd/runner/main.go
 

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -49,7 +49,8 @@ func main() {
 	fmt.Println("total:", len(rec))
 }
 
-// makeRunnerConfig retrieves a config from
+// makeRunnerConfig returns a config.Config initialized with config file
+// options if found, overridden with CLI options.
 func makeRunnerConfig() config.Config {
 	fileConfig, err := configfile.Parse(configFile)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {

--- a/config/config.go
+++ b/config/config.go
@@ -34,8 +34,14 @@ func (cfg Config) String() string {
 
 // New returns a default Config overridden with given parameters.
 func New(uri string, requests, concurrency int, requestTimeout, globalTimeout time.Duration) Config {
-	cfg := Config{
+	var urlURL *url.URL
+	if uri != "" {
+		// ignore err: a Config can be invalid at this point
+		urlURL, _ = url.Parse(uri)
+	}
+	return Config{
 		Request: Request{
+			URL:     urlURL,
 			Timeout: requestTimeout,
 		},
 		RunnerOptions: RunnerOptions{
@@ -44,9 +50,6 @@ func New(uri string, requests, concurrency int, requestTimeout, globalTimeout ti
 			GlobalTimeout: globalTimeout,
 		},
 	}
-	cfg.Request.URL, _ = url.Parse(uri) // TODO: error handling
-
-	return MergeDefault(cfg)
 }
 
 // Default returns a default config that is safe to use.

--- a/config/config.go
+++ b/config/config.go
@@ -7,12 +7,14 @@ import (
 	"time"
 )
 
+// Request contains the confing options relative to a single request.
 type Request struct {
 	Method  string
 	URL     *url.URL
 	Timeout time.Duration
 }
 
+// RunnerOptions contains options relative to the runner.
 type RunnerOptions struct {
 	Requests      int
 	Concurrency   int
@@ -20,6 +22,7 @@ type RunnerOptions struct {
 }
 
 // Config represents the configuration of the runner.
+// It must be validated using Config.Validate before usage.
 type Config struct {
 	Request       Request
 	RunnerOptions RunnerOptions
@@ -32,7 +35,9 @@ func (cfg Config) String() string {
 	return string(b)
 }
 
-// New returns a Config initialized with given parameters.
+// New returns a Config initialized with given parameters. The returned Config
+// is not guaranteed to be safe: it must be validated using Config.Validate
+// before usage.
 func New(uri string, requests, concurrency int, requestTimeout, globalTimeout time.Duration) Config {
 	var urlURL *url.URL
 	if uri != "" {
@@ -58,7 +63,8 @@ func Default() Config {
 }
 
 // Merge returns a Config after a base Config overridden by all non-zero values
-// of override.
+// of override. The returned Config is not guaranteed to be safe: it must be
+// validated using Config.Validate before usage.
 func Merge(base, override Config) Config {
 	if override.Request.Method != "" {
 		base.Request.Method = override.Request.Method
@@ -83,6 +89,8 @@ func Merge(base, override Config) Config {
 }
 
 // MergeDefault merges override with the default config calling Merge.
+// The returned Config is not guaranteed to be safe: it must be validated
+// using Config.Validate before usage.
 func MergeDefault(override Config) Config {
 	return Merge(Default(), override)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func (cfg Config) String() string {
 	return string(b)
 }
 
-// New returns a default Config overridden with given parameters.
+// New returns a Config initialized with given parameters.
 func New(uri string, requests, concurrency int, requestTimeout, globalTimeout time.Duration) Config {
 	var urlURL *url.URL
 	if uri != "" {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -73,26 +73,26 @@ func TestMerge(t *testing.T) {
 }
 
 func TestNew(t *testing.T) {
-	t.Run("use default config as base", func(t *testing.T) {
-		exp := config.Default()
+	t.Run("zero value params return empty config", func(t *testing.T) {
+		exp := config.Config{}
 		if got := config.New("", 0, 0, 0, 0); !reflect.DeepEqual(got, exp) {
-			t.Errorf("did not use default config as base:\nexp %#v\ngot %#v", exp, got)
+			t.Errorf("returned non-zero config:\nexp %#v\ngot %#v", exp, got)
 		}
 	})
 
-	t.Run("override default with params", func(t *testing.T) {
+	t.Run("non-zero params return initialized config", func(t *testing.T) {
 		var (
 			rawURL      = "http://example.com"
 			urlURL, _   = url.Parse(rawURL)
-			requests    = 10
-			concurrency = 10
-			reqTimeout  = 2 * time.Second
-			glbTimeout  = 10 * time.Second
+			requests    = 1
+			concurrency = 2
+			reqTimeout  = 3 * time.Second
+			glbTimeout  = 4 * time.Second
 		)
 
 		exp := config.Config{
 			Request: config.Request{
-				Method:  "GET",
+				Method:  "",
 				URL:     urlURL,
 				Timeout: reqTimeout,
 			},
@@ -106,7 +106,7 @@ func TestNew(t *testing.T) {
 		got := config.New(rawURL, requests, concurrency, reqTimeout, glbTimeout)
 
 		if !reflect.DeepEqual(got, exp) {
-			t.Errorf("did not override with params:\nexp %#v\ngot %#v", exp, got)
+			t.Errorf("returned unexpected config:\nexp %#v\ngot %#v", exp, got)
 		}
 	})
 }


### PR DESCRIPTION
<!-- IMPORTANT: Don't forget to link the issue(s) once the PR created! -->

## Description

Fixes #24 

<!--
    Describe briefly what this PR does, if the issue description is not enough.
    Add any information that could be relevant for the reviewers.
-->

## Changes

- `config.New` does not return a merged config with `config.Default` anymore
- Updated unit tests accordingly
- Updated docs accordingly

<!-- Optional: mention here indirect changes impacted by the PR -->

## Notes

<!-- Optional: additional notes than can help understanding the implementation -->
