### PR TITLE
feat: implement proper error handling for requester

### DIFF
--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -49,7 +49,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if err := requester.New(cfg).RunAndReport(serverURL); err != nil {
+	if err := requester.New(cfg).RunAndSendReport(serverURL); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -73,7 +74,7 @@ func New(uri string, requests, concurrency int, requestTimeout, globalTimeout ti
 }
 
 // Validate returns the config and a not nil ErrInvalid if any of the fields provided by the user is not valid
-func (cfg Config) Validate() error { //nolint
+func (cfg Config) Validate() error { //nolint:gocognit
 	inputErrors := []error{}
 
 	_, err := url.ParseRequestURI(cfg.Request.URL.String())

--- a/config/config.go
+++ b/config/config.go
@@ -39,11 +39,15 @@ func (cfg Config) String() string {
 // HTTPRequest returns a *http.Request created from Target. Returns any non-nil
 // error that occurred.
 func (cfg Config) HTTPRequest() (*http.Request, error) {
-	return http.NewRequest(
-		cfg.Request.Method,
-		cfg.Request.URL.String(),
-		nil, // TODO: handle body
-	)
+	if cfg.Request.URL == nil {
+		return nil, errors.New("empty url")
+	}
+	rawURL := cfg.Request.URL.String()
+	if _, err := url.ParseRequestURI(rawURL); err != nil {
+		return nil, errors.New("bad url")
+	}
+	// TODO: handle body
+	return http.NewRequest(cfg.Request.Method, rawURL, nil)
 }
 
 // New returns a Config initialized with given parameters. The returned Config

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -30,7 +30,7 @@ func (d dispatcher) Do(ctx context.Context, maxIter int, callback func()) error 
 
 	wg := sync.WaitGroup{}
 
-	for i := 0; i < maxIter || maxIter == 0; i++ {
+	for i := 0; i < maxIter || maxIter == -1; i++ {
 		wg.Add(1)
 
 		if err := d.sem.Acquire(ctx, 1); err != nil {
@@ -54,10 +54,10 @@ func (d dispatcher) Do(ctx context.Context, maxIter int, callback func()) error 
 }
 
 func (d dispatcher) validate(maxIter int, callback func()) error {
-	if maxIter < 1 {
-		return fmt.Errorf("%w: maxIter: must be < 1, got %d", ErrInvalidValue, maxIter)
+	if maxIter < 1 && maxIter != -1 {
+		return fmt.Errorf("%w: maxIter: must be -1 or >= 1, got %d", ErrInvalidValue, maxIter)
 	}
-	if maxIter < d.numWorker {
+	if maxIter < d.numWorker && maxIter != -1 {
 		return fmt.Errorf(
 			"%w: maxIter: must be >= numWorker (%d), got %d",
 			ErrInvalidValue, d.numWorker, maxIter,

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -2,6 +2,7 @@ package dispatcher
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"golang.org/x/sync/semaphore"
@@ -48,16 +49,11 @@ func (d dispatcher) Do(ctx context.Context, maxIter int, callback func()) {
 
 // New returns a Dispatcher initialized with numWorker.
 func New(numWorker int) Dispatcher {
-	numWorker = sanitizeNumWorker(numWorker)
+	if numWorker < 1 {
+		panic(fmt.Sprintf("invalid numWorker value: must be > 1, got %d", numWorker))
+	}
 	sem := semaphore.NewWeighted(int64(numWorker))
 	return dispatcher{sem: sem}
-}
-
-func sanitizeNumWorker(numWorkers int) int {
-	if numWorkers < 1 {
-		return 1
-	}
-	return numWorkers
 }
 
 func sanitizeMaxIter(maxIter int) int {

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -20,6 +20,15 @@ type dispatcher struct {
 	sem       *semaphore.Weighted
 }
 
+// New returns a Dispatcher initialized with numWorker.
+func New(numWorker int) Dispatcher {
+	if numWorker < 1 {
+		panic(fmt.Sprintf("invalid numWorker value: must be > 1, got %d", numWorker))
+	}
+	sem := semaphore.NewWeighted(int64(numWorker))
+	return dispatcher{sem: sem, numWorker: numWorker}
+}
+
 // Do concurrently executes callback at most maxIter times or until ctx is done
 // or canceled. Concurrency is handled leveraging the semaphore pattern, which
 // ensures at most Dispatcher.numWorkers goroutines are spawned at the same time.
@@ -67,13 +76,4 @@ func (d dispatcher) validate(maxIter int, callback func()) error {
 		return fmt.Errorf("%w: callback: must be non-nil", ErrInvalidValue)
 	}
 	return nil
-}
-
-// New returns a Dispatcher initialized with numWorker.
-func New(numWorker int) Dispatcher {
-	if numWorker < 1 {
-		panic(fmt.Sprintf("invalid numWorker value: must be > 1, got %d", numWorker))
-	}
-	sem := semaphore.NewWeighted(int64(numWorker))
-	return dispatcher{sem: sem, numWorker: numWorker}
 }

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -2,26 +2,31 @@ package dispatcher
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
 	"golang.org/x/sync/semaphore"
 )
 
+var ErrInvalidValue = errors.New("invalid value")
+
 type Dispatcher interface {
-	Do(ctx context.Context, maxIter int, callback func())
+	Do(ctx context.Context, maxIter int, callback func()) error
 }
 
 type dispatcher struct {
-	sem *semaphore.Weighted
+	numWorker int
+	sem       *semaphore.Weighted
 }
 
 // Do concurrently executes callback at most maxIter times or until ctx is done
 // or canceled. Concurrency is handled leveraging the semaphore pattern, which
 // ensures at most Dispatcher.numWorkers goroutines are spawned at the same time.
-func (d dispatcher) Do(ctx context.Context, maxIter int, callback func()) {
-	maxIter = sanitizeMaxIter(maxIter)
-	callback = sanitizeCallback(callback)
+func (d dispatcher) Do(ctx context.Context, maxIter int, callback func()) error {
+	if err := d.validate(maxIter, callback); err != nil {
+		return err
+	}
 
 	wg := sync.WaitGroup{}
 
@@ -45,6 +50,23 @@ func (d dispatcher) Do(ctx context.Context, maxIter int, callback func()) {
 	}
 
 	wg.Wait()
+	return nil
+}
+
+func (d dispatcher) validate(maxIter int, callback func()) error {
+	if maxIter < 1 {
+		return fmt.Errorf("%w: maxIter: must be < 1, got %d", ErrInvalidValue, maxIter)
+	}
+	if maxIter < d.numWorker {
+		return fmt.Errorf(
+			"%w: maxIter: must be >= numWorker, got numWorker == %d, maxIter == %d",
+			ErrInvalidValue, maxIter, d.numWorker,
+		)
+	}
+	if callback == nil {
+		return fmt.Errorf("%w: callback: must be non-nil", ErrInvalidValue)
+	}
+	return nil
 }
 
 // New returns a Dispatcher initialized with numWorker.
@@ -53,19 +75,5 @@ func New(numWorker int) Dispatcher {
 		panic(fmt.Sprintf("invalid numWorker value: must be > 1, got %d", numWorker))
 	}
 	sem := semaphore.NewWeighted(int64(numWorker))
-	return dispatcher{sem: sem}
-}
-
-func sanitizeMaxIter(maxIter int) int {
-	if maxIter < 0 {
-		return 0
-	}
-	return maxIter
-}
-
-func sanitizeCallback(callback func()) func() {
-	if callback == nil {
-		return func() {}
-	}
-	return callback
+	return dispatcher{sem: sem, numWorker: numWorker}
 }

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -59,8 +59,8 @@ func (d dispatcher) validate(maxIter int, callback func()) error {
 	}
 	if maxIter < d.numWorker {
 		return fmt.Errorf(
-			"%w: maxIter: must be >= numWorker, got numWorker == %d, maxIter == %d",
-			ErrInvalidValue, maxIter, d.numWorker,
+			"%w: maxIter: must be >= numWorker (%d), got %d",
+			ErrInvalidValue, d.numWorker, maxIter,
 		)
 	}
 	if callback == nil {

--- a/requester/error.go
+++ b/requester/error.go
@@ -1,0 +1,14 @@
+package requester
+
+import "errors"
+
+var (
+	// ErrRequest is returned when an invalid *http.Request is generated
+	// by the Requester config.
+	ErrRequest = errors.New("invalid request")
+	// ErrConnection is returned when the Requester fails to connect to
+	// the requested URL.
+	ErrConnection = errors.New("connection error")
+	// ErrReporting is returned when the Requester fails to send the report.
+	ErrReporting = errors.New("reporting error")
+)

--- a/requester/report.go
+++ b/requester/report.go
@@ -24,13 +24,13 @@ func (rep Report) String() string {
 }
 
 // report generates and returns a Report from a previous Run.
-func (r *Requester) report() Report {
+func makeReport(cfg config.Config, records []Record, numErr int) Report {
 	return Report{
-		Config:  r.config,
-		Records: r.records,
-		Length:  len(r.records),
-		Success: len(r.records) - r.numErr,
-		Fail:    r.numErr,
+		Config:  cfg,
+		Records: records,
+		Length:  len(records),
+		Success: len(records) - numErr,
+		Fail:    numErr,
 	}
 }
 

--- a/requester/report.go
+++ b/requester/report.go
@@ -53,21 +53,21 @@ func (r *Requester) collect() (Report, error) {
 func (r *Requester) Report(url string, report Report) error {
 	body := bytes.Buffer{}
 	if err := json.NewEncoder(&body).Encode(report); err != nil {
-		return fmt.Errorf("error sending the report: %s", err)
+		return fmt.Errorf("%w: %s", ErrReporting, err)
 	}
 
 	req, err := http.NewRequest("POST", url, &body)
 	if err != nil {
-		return fmt.Errorf("error sending the report: %s", err)
+		return fmt.Errorf("%w: %s", ErrReporting, err)
 	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("error sending the report: %s", err)
+		return fmt.Errorf("%w: %s", ErrReporting, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("error sending the report: %s", resp.Status)
+		return fmt.Errorf("%w: %s", ErrReporting, resp.Status)
 	}
 
 	return nil

--- a/requester/report.go
+++ b/requester/report.go
@@ -73,10 +73,14 @@ func (r *Requester) Report(url string, report Report) error {
 // invocation. It's useful for simple usecases where the
 // caller don't need to known about the Report.
 func (r *Requester) RunAndReport(url string) error {
-	report := r.Run()
+	report, err := r.Run()
+	if err != nil {
+		return err
+	}
 
 	if err := r.Report(url, report); err != nil {
 		return err
 	}
+
 	return nil
 }

--- a/requester/report.go
+++ b/requester/report.go
@@ -36,9 +36,8 @@ func (r *Requester) collect() Report {
 	for rec := range r.records {
 		if rec.Error != nil {
 			rep.Fail++
-		} else {
-			rep.Records = append(rep.Records, rec)
 		}
+		rep.Records = append(rep.Records, rec)
 	}
 	rep.Length = len(rep.Records)
 	rep.Success = rep.Length - rep.Fail

--- a/requester/report.go
+++ b/requester/report.go
@@ -9,6 +9,10 @@ import (
 	"github.com/benchttp/runner/config"
 )
 
+const (
+	defaultRecordsCap = 128
+)
+
 // Report represents the collected results of a benchmark test.
 type Report struct {
 	Config  config.Config `json:"config"`
@@ -28,9 +32,14 @@ func (rep Report) String() string {
 // Returns the report when all the records have been collected.
 // Requester.collect will blocks until Requester.Records is empty.
 func (r *Requester) collect() (Report, error) {
+	recordsCap := defaultRecordsCap
+	if r.config.RunnerOptions.Requests > 0 {
+		recordsCap = r.config.RunnerOptions.Requests
+	}
+
 	rep := Report{
 		Config:  r.config,
-		Records: make([]Record, 0, r.config.RunnerOptions.Requests), // Provide capacity if known.
+		Records: make([]Record, 0, recordsCap), // Provide capacity if known.
 	}
 
 	for rec := range r.recordC {

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -27,7 +27,7 @@ type Requester struct {
 func New(cfg config.Config) *Requester {
 	tracer := newTracer()
 	return &Requester{
-		recordC: make(chan Record, cfg.RunnerOptions.Requests),
+		recordC: make(chan Record),
 		errC:    make(chan error),
 		config:  cfg,
 		tracer:  tracer,

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/benchttp/runner/config"
-	"github.com/benchttp/runner/semimpl"
+	"github.com/benchttp/runner/dispatcher"
 )
 
 // Requester executes the benchmark. It wraps http.Client.
@@ -46,11 +46,9 @@ func (r *Requester) Run() Report {
 	go func() {
 		defer cancel()
 		defer close(r.records)
-		semimpl.Do(ctx,
-			r.config.RunnerOptions.Concurrency,
-			r.config.RunnerOptions.Requests,
-			r.record,
-		)
+		dispatcher.
+			New(r.config.RunnerOptions.Concurrency).
+			Do(ctx, r.config.RunnerOptions.Requests, r.record)
 	}()
 
 	return r.collect()

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -46,6 +46,10 @@ func (r *Requester) Run() (Report, error) {
 		return Report{}, err
 	}
 
+	if err := r.ping(req); err != nil {
+		return Report{}, err
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), r.config.RunnerOptions.GlobalTimeout)
 	errCh := make(chan error)
 
@@ -63,6 +67,14 @@ func (r *Requester) Run() (Report, error) {
 	}
 
 	return r.collect(), nil
+}
+
+func (r *Requester) ping(req *http.Request) error {
+	resp, err := r.client.Do(req)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	return err
 }
 
 // Record is the summary of a HTTP response. If Record.Error is non-nil,

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -80,7 +80,7 @@ func (r *Requester) Run() (Report, error) {
 		return Report{}, err
 	}
 
-	return r.report(), nil
+	return makeReport(r.config, r.records, r.numErr), nil
 }
 
 func (r *Requester) ping(req *http.Request) error {

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -2,7 +2,6 @@ package requester
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,11 +9,6 @@ import (
 
 	"github.com/benchttp/runner/config"
 	"github.com/benchttp/runner/dispatcher"
-)
-
-var (
-	ErrRequest    = errors.New("invalid request")
-	ErrConnection = errors.New("connection error")
 )
 
 // Requester executes the benchmark. It wraps http.Client.

--- a/requester/requester_internal_test.go
+++ b/requester/requester_internal_test.go
@@ -26,12 +26,12 @@ func TestRun(t *testing.T) {
 	}{
 		{
 			label: "return ErrRequest early on request error",
-			req:   New(config.New(badURL, 0, 0, 0, 0)),
+			req:   New(config.New(badURL, -1, 1, 0, 0)),
 			exp:   ErrRequest,
 		},
 		{
 			label: "return ErrConnection early on connection error",
-			req:   New(config.New(goodURL, 0, 0, 0, 0)),
+			req:   New(config.New(goodURL, -1, 1, 0, 0)),
 			exp:   ErrConnection,
 		},
 		{
@@ -50,7 +50,7 @@ func TestRun(t *testing.T) {
 			}
 
 			if !reflect.ValueOf(gotRep).IsZero() {
-				t.Errorf("report value:\nexp %v, got %v", Report{}, gotRep)
+				t.Errorf("report value:\nexp %v\ngot %v", Report{}, gotRep)
 			}
 		})
 	}
@@ -79,7 +79,7 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("happy path", func(t *testing.T) {
-		r := withNoopTransport(New(config.New(goodURL, 1, 1, time.Second, time.Minute)))
+		r := withNoopTransport(New(config.New(goodURL, 1, 1, time.Second, 2*time.Second)))
 
 		rep, err := r.Run()
 		if err != nil {

--- a/requester/requester_internal_test.go
+++ b/requester/requester_internal_test.go
@@ -1,0 +1,137 @@
+package requester
+
+import (
+	"errors"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/benchttp/runner/config"
+	"github.com/benchttp/runner/dispatcher"
+)
+
+const (
+	badURL  = "abc"
+	goodURL = "http://a.b"
+)
+
+var errTest = errors.New("test-generated error")
+
+func TestRun(t *testing.T) {
+	testcases := []struct {
+		label string
+		req   *Requester
+		exp   error
+	}{
+		{
+			label: "return ErrRequest early on request error",
+			req:   New(config.New(badURL, 0, 0, 0, 0)),
+			exp:   ErrRequest,
+		},
+		{
+			label: "return ErrConnection early on connection error",
+			req:   New(config.New(goodURL, 0, 0, 0, 0)),
+			exp:   ErrConnection,
+		},
+		{
+			label: "return dispatcher.ErrInvalidValue early on bad dispatcher value",
+			req:   withNoopTransport(New(config.New(goodURL, 1, 2, time.Second, time.Minute))),
+			exp:   dispatcher.ErrInvalidValue,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.label, func(t *testing.T) {
+			gotRep, gotErr := tc.req.Run()
+
+			if !errors.Is(gotErr, tc.exp) {
+				t.Errorf("unexpected error value:\nexp %v\ngot %v", tc.exp, gotErr)
+			}
+
+			if !reflect.ValueOf(gotRep).IsZero() {
+				t.Errorf("report value:\nexp %v, got %v", Report{}, gotRep)
+			}
+		})
+	}
+
+	t.Run("record failing requests", func(t *testing.T) {
+		r := withErrTransport(New(config.New(goodURL, 1, 1, time.Second, time.Minute)))
+
+		rep, err := r.Run()
+		if err != nil {
+			t.Errorf("exp nil error, got %v", err)
+		}
+
+		if rep.Length != 1 {
+			t.Errorf("unexpected Report.Length: exp 1, got %d", rep.Length)
+		}
+
+		if rep.Success != 0 {
+			t.Errorf("unexpected Report.Success: exp 0, got %d", rep.Success)
+		}
+
+		if rep.Fail != 1 {
+			t.Errorf("unexpected Report.Fail: exp 1, got %d", rep.Fail)
+		}
+
+		t.Log(rep)
+	})
+
+	t.Run("happy path", func(t *testing.T) {
+		r := withNoopTransport(New(config.New(goodURL, 1, 1, time.Second, time.Minute)))
+
+		rep, err := r.Run()
+		if err != nil {
+			t.Errorf("exp nil error, got %v", err)
+		}
+
+		if rep.Length != 1 {
+			t.Errorf("unexpected Report.Length: exp 1, got %d", rep.Length)
+		}
+
+		if rep.Success != 1 {
+			t.Errorf("unexpected Report.Success: exp 1, got %d", rep.Success)
+		}
+
+		if rep.Fail != 0 {
+			t.Errorf("unexpected Report.Fail: exp 0, got %d", rep.Fail)
+		}
+
+		t.Log(rep)
+	})
+}
+
+// helpers
+
+type noopTransport struct{}
+
+func (noopTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{}, nil
+}
+
+func withNoopTransport(req *Requester) *Requester {
+	req.client.Transport = noopTransport{}
+	return req
+}
+
+type errTransport struct{}
+
+func (errTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{Body: unreadableReadCloser{}}, nil
+}
+
+func withErrTransport(req *Requester) *Requester {
+	req.client.Transport = errTransport{}
+	return req
+}
+
+type unreadableReadCloser struct{}
+
+func (unreadableReadCloser) Read([]byte) (int, error) {
+	return 0, errTest
+}
+
+func (unreadableReadCloser) Close() error {
+	return nil
+}


### PR DESCRIPTION
<!-- IMPORTANT: Don't forget to link the issue(s) once the PR created! -->

## Description

This PR implements proper error handling for `requester` and `dispatcher` (formerly `semimpl`).

<!--
    Describe briefly what this PR does, if the issue description is not enough.
    Add any information that could be relevant for the reviewers.
-->

## Changes

### Refactoring: `semimpl` ➡️ `dispatcher`
  ```go
  // before
  semimpl.Do(ctx, 100, 10, callback) // notice the error?
  
  // after
  dispatcher.New(10).Do(ctx, 100, callback)
  ```

### Error handling: `dispatcher`

- `dispatcher.New` **panics** if `numWorker < 1`
- `dispatcher.Dispatcher.Do` returns a non-nil error early if
  - `maxIter < 1 && maxIter != -1`
  - `maxIter < Dispatcher.numWorker && maxIter != -1`
  - `callback == nil`
- New unit tests for all cases

### Error handling: `requester`
- Handle `config.HTTPRequest()` error in `Dispatcher.Run` instead of repeated callback
- Handle `client.Do` connection error in `Dispatcher.Run` in addition to the callback via a ping to return early in case of bad URL, server not started, ...


<!-- Optional: mention here indirect changes impacted by the PR -->

## Notes

<!-- Optional: additional notes than can help understanding the implementation -->
