### PR TITLE
dev: refactor config responsibilities

### DIFF
--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -92,14 +92,14 @@ func run() error {
 
 // parseConfig returns a config.Config initialized with config file
 // options if found, overridden with CLI options.
-func parseConfig() (cfg config.Config, err error) {
+func parseConfig() (cfg config.Global, err error) {
 	fileCfg, err := configfile.Parse(configFile)
 	if err != nil && !errors.Is(err, configfile.ErrFileNotFound) {
 		// config file is not mandatory, other errors are critical
 		return
 	}
 
-	cliCfg := config.Config{
+	cliCfg := config.Global{
 		Request: config.Request{
 			Header: header,
 		},

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -72,7 +72,18 @@ func run() error {
 		return err
 	}
 
-	if err := requester.New(cfg).RunAndSendReport(reportURL); err != nil {
+	req, err := cfg.HTTPRequest()
+	if err != nil {
+		return err
+	}
+
+	rep, err := requester.New(requester.Config(cfg.Runner)).Run(req)
+	if err != nil {
+		return err
+	}
+
+	// TODO: handle output
+	if err := requester.SendReport(reportURL, rep); err != nil {
 		return err
 	}
 

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -77,7 +77,7 @@ func run() error {
 		return err
 	}
 
-	rep, err := requester.New(requester.Config(cfg.Runner)).Run(req)
+	rep, err := requester.New(cfg).Run(req)
 	if err != nil {
 		return err
 	}

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -72,7 +72,7 @@ func run() error {
 		return err
 	}
 
-	req, err := cfg.HTTPRequest()
+	req, err := cfg.Request.HTTP()
 	if err != nil {
 		return err
 	}

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -20,14 +20,14 @@ const (
 )
 
 var (
-	configFile    string
-	uri           string
-	header        = http.Header{}
-	concurrency   int           // Number of connections to run concurrently
-	requests      int           // Number of requests to run, use duration as exit condition if omitted.
-	timeout       time.Duration // Timeout for each HTTP request
-	interval      time.Duration // Minimum duration between two groups of requests
-	globalTimeout time.Duration // Duration of test
+	configFile     string
+	uri            string
+	header         = http.Header{}
+	concurrency    int           // Number of connections to run concurrently
+	requests       int           // Number of requests to run, use duration as exit condition if omitted.
+	interval       time.Duration // Minimum duration between two groups of requests
+	requestTimeout time.Duration // Timeout for each HTTP request
+	globalTimeout  time.Duration // Duration of test
 )
 
 var defaultConfigFiles = []string{
@@ -44,14 +44,14 @@ func parseArgs() {
 	flag.StringVar(&uri, config.FieldURL, "", "Target URL to request")
 	// request header
 	flag.Var(headerValue{header: &header}, config.FieldHeader, "HTTP request header")
-	// request timeout
-	flag.DurationVar(&timeout, config.FieldTimeout, 0, "Timeout for each HTTP request")
 	// concurrency
 	flag.IntVar(&concurrency, config.FieldConcurrency, 0, "Number of connections to run concurrently")
 	// requests number
 	flag.IntVar(&requests, config.FieldRequests, 0, "Number of requests to run, use duration as exit condition if omitted")
 	// non-conurrent requests interval
 	flag.DurationVar(&interval, "interval", 0, "Minimum duration between two non concurrent requests")
+	// request timeout
+	flag.DurationVar(&requestTimeout, config.FieldRequestTimeout, 0, "Timeout for each HTTP request")
 	// global timeout
 	flag.DurationVar(&globalTimeout, config.FieldGlobalTimeout, 0, "Max duration of test")
 
@@ -90,14 +90,14 @@ func parseConfig() (cfg config.Config, err error) {
 
 	cliCfg := config.Config{
 		Request: config.Request{
-			Header:  header,
-			Timeout: timeout,
+			Header: header,
 		},
 		RunnerOptions: config.RunnerOptions{
-			Requests:      requests,
-			Concurrency:   concurrency,
-			Interval:      interval,
-			GlobalTimeout: globalTimeout,
+			Requests:       requests,
+			Concurrency:    concurrency,
+			Interval:       interval,
+			RequestTimeout: requestTimeout,
+			GlobalTimeout:  globalTimeout,
 		},
 	}.WithURL(uri)
 

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -102,7 +102,7 @@ func parseConfig() (cfg config.Global, err error) {
 	cliCfg := config.Global{
 		Request: config.Request{
 			Header: header,
-		},
+		}.WithURL(uri),
 		Runner: config.Runner{
 			Requests:       requests,
 			Concurrency:    concurrency,
@@ -110,7 +110,7 @@ func parseConfig() (cfg config.Global, err error) {
 			RequestTimeout: requestTimeout,
 			GlobalTimeout:  globalTimeout,
 		},
-	}.WithURL(uri)
+	}
 
 	mergedConfig := fileCfg.Override(cliCfg, configFlags()...)
 

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -77,7 +77,7 @@ func run() error {
 		return err
 	}
 
-	rep, err := requester.New(cfg).Run(req)
+	rep, err := requester.New(requester.Config(cfg.Runner)).Run(req)
 	if err != nil {
 		return err
 	}

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -92,7 +92,7 @@ func parseConfig() (cfg config.Config, err error) {
 		Request: config.Request{
 			Header: header,
 		},
-		RunnerOptions: config.RunnerOptions{
+		Runner: config.Runner{
 			Requests:       requests,
 			Concurrency:    concurrency,
 			Interval:       interval,

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -72,7 +72,7 @@ func run() error {
 		return err
 	}
 
-	req, err := cfg.Request.HTTP()
+	req, err := cfg.Request.Value()
 	if err != nil {
 		return err
 	}

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -28,7 +28,7 @@ var (
 	// If type is "raw", content is the data as a string. If type is "file",
 	// content is the path to the file holding the data. Note: only "raw"
 	// is supported at the moment.
-	body           string
+	body           config.Body
 	concurrency    int           // Number of connections to run concurrently
 	requests       int           // Number of requests to run, use duration as exit condition if omitted.
 	interval       time.Duration // Minimum duration between two groups of requests
@@ -50,6 +50,8 @@ func parseArgs() {
 	flag.StringVar(&uri, config.FieldURL, "", "Target URL to request")
 	// request header
 	flag.Var(headerValue{header: &header}, config.FieldHeader, "HTTP request header")
+	// request body
+	flag.Var(bodyValue{body: &body}, config.FieldBody, "HTTP request body")
 	// concurrency
 	flag.IntVar(&concurrency, config.FieldConcurrency, 0, "Number of connections to run concurrently")
 	// requests number
@@ -62,8 +64,6 @@ func parseArgs() {
 	flag.DurationVar(&globalTimeout, config.FieldGlobalTimeout, 0, "Max duration of test")
 	// request method
 	flag.StringVar(&method, config.FieldMethod, "", "HTTP request method")
-	// body
-	flag.StringVar(&body, config.FieldBody, "", "HTTP request body")
 	flag.Parse()
 }
 
@@ -108,11 +108,6 @@ func parseConfig() (cfg config.Global, err error) {
 		return
 	}
 
-	body, err := config.ParseBody(body)
-	if err != nil {
-		return cfg, nil
-	}
-
 	cliCfg := config.Global{
 		Request: config.Request{
 			Header: header,
@@ -155,12 +150,60 @@ func (v headerValue) String() string {
 
 // Set reads input string in format "key:value" and appends value
 // to the key's values of the referenced header.
-func (v headerValue) Set(in string) error {
-	keyval := strings.Split(in, ":")
+func (v headerValue) Set(raw string) error {
+	keyval := strings.SplitN(raw, ":", 2)
 	if len(keyval) != 2 {
-		return errors.New(`expect format key:value`)
+		return errors.New(`expect format "<key>:<value>"`)
 	}
 	key, val := keyval[0], keyval[1]
 	(*v.header)[key] = append((*v.header)[key], val)
+	return nil
+}
+
+// bodyValue implements flag.Value
+type bodyValue struct {
+	body *config.Body
+}
+
+// String returns a string representation of the referenced body.
+func (v bodyValue) String() string {
+	return fmt.Sprint(v.body)
+}
+
+// Set reads input string in format "type:content" and sets
+// the referenced body accordingly.
+//
+// If type is "raw", content is the data as a string.
+//	"raw:{\"key\":\"value\"}" // escaped JSON
+//	"raw:text" // plain text
+// If type is "file", content is the path to the file holding the data.
+//	"file:./path/to/file.txt"
+//
+// Note: only type "raw" is supported at the moment.
+func (v bodyValue) Set(raw string) error {
+	errFormat := fmt.Errorf(`expect format "<type>:<content>", got "%s"`, raw)
+
+	if raw == "" {
+		return errFormat
+	}
+
+	split := strings.SplitN(raw, ":", 2)
+	if len(split) != 2 {
+		return errFormat
+	}
+
+	btype, bcontent := split[0], split[1]
+	if bcontent == "" {
+		return errFormat
+	}
+
+	switch btype {
+	case "raw":
+		*v.body = config.NewBody(btype, bcontent)
+	// case "file":
+	// 	// TODO
+	default:
+		return fmt.Errorf(`unsupported type: %s (only "raw" accepted`, btype)
+	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -25,23 +25,23 @@ type Runner struct {
 	GlobalTimeout  time.Duration
 }
 
-// Config represents the configuration of the runner.
-// It must be validated using Config.Validate before usage.
-type Config struct {
+// Global represents the global configuration of the runner.
+// It must be validated using Global.Validate before usage.
+type Global struct {
 	Request Request
 	Runner  Runner
 }
 
 // String returns an indented JSON representation of Config
 // for debugging purposes.
-func (cfg Config) String() string {
+func (cfg Global) String() string {
 	b, _ := json.MarshalIndent(cfg, "", "  ")
 	return string(b)
 }
 
 // HTTPRequest returns a *http.Request created from Target. Returns any non-nil
 // error that occurred.
-func (cfg Config) HTTPRequest() (*http.Request, error) {
+func (cfg Global) HTTPRequest() (*http.Request, error) {
 	if cfg.Request.URL == nil {
 		return nil, errors.New("empty url")
 	}
@@ -61,7 +61,7 @@ func (cfg Config) HTTPRequest() (*http.Request, error) {
 // Override returns a new Config based on cfg with overridden values from c.
 // Only fields specified in options are replaced. Accepted options are limited
 // to existing Fields, other values are silently ignored.
-func (cfg Config) Override(c Config, fields ...string) Config {
+func (cfg Global) Override(c Global, fields ...string) Global {
 	for _, field := range fields {
 		switch field {
 		case FieldMethod:
@@ -85,7 +85,7 @@ func (cfg Config) Override(c Config, fields ...string) Config {
 	return cfg
 }
 
-func (cfg *Config) overrideHeader(newHeader http.Header) {
+func (cfg *Global) overrideHeader(newHeader http.Header) {
 	if newHeader == nil {
 		return
 	}
@@ -100,7 +100,7 @@ func (cfg *Config) overrideHeader(newHeader http.Header) {
 // WithURL sets the current Config to the parsed *url.URL from rawURL
 // and returns it. Any errors is discarded as a Config can be invalid
 // until Config.Validate is called. The url is guaranteed not to be nil.
-func (cfg Config) WithURL(rawURL string) Config {
+func (cfg Global) WithURL(rawURL string) Global {
 	// ignore err: a Config can be invalid at this point
 	urlURL, _ := url.ParseRequestURI(rawURL)
 	if urlURL == nil {
@@ -111,7 +111,7 @@ func (cfg Config) WithURL(rawURL string) Config {
 }
 
 // Validate returns the config and a not nil ErrInvalid if any of the fields provided by the user is not valid
-func (cfg Config) Validate() error { //nolint:gocognit
+func (cfg Global) Validate() error { //nolint:gocognit
 	inputErrors := []error{}
 
 	if cfg.Request.URL == nil {
@@ -147,6 +147,6 @@ func (cfg Config) Validate() error { //nolint:gocognit
 }
 
 // Default returns a default config that is safe to use.
-func Default() Config {
+func Default() Global {
 	return defaultConfig
 }

--- a/config/config.go
+++ b/config/config.go
@@ -27,7 +27,6 @@ type Runner struct {
 
 // Global represents the global configuration of the runner.
 // It must be validated using Global.Validate before usage.
-// It implements requester.Config
 type Global struct {
 	Request Request
 	Runner  Runner
@@ -145,28 +144,6 @@ func (cfg Global) Validate() error { //nolint:gocognit
 		return &ErrInvalid{inputErrors}
 	}
 	return nil
-}
-
-// requester.Config implementation
-
-func (cfg Global) Requests() int {
-	return cfg.Runner.Requests
-}
-
-func (cfg Global) Concurrency() int {
-	return cfg.Runner.Concurrency
-}
-
-func (cfg Global) Interval() time.Duration {
-	return cfg.Runner.Interval
-}
-
-func (cfg Global) RequestTimeout() time.Duration {
-	return cfg.Runner.RequestTimeout
-}
-
-func (cfg Global) GlobalTimeout() time.Duration {
-	return cfg.Runner.GlobalTimeout
 }
 
 // Default returns a default config that is safe to use.

--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,7 @@ type Runner struct {
 
 // Global represents the global configuration of the runner.
 // It must be validated using Global.Validate before usage.
+// It implements requester.Config
 type Global struct {
 	Request Request
 	Runner  Runner
@@ -144,6 +145,28 @@ func (cfg Global) Validate() error { //nolint:gocognit
 		return &ErrInvalid{inputErrors}
 	}
 	return nil
+}
+
+// requester.Config implementation
+
+func (cfg Global) Requests() int {
+	return cfg.Runner.Requests
+}
+
+func (cfg Global) Concurrency() int {
+	return cfg.Runner.Concurrency
+}
+
+func (cfg Global) Interval() time.Duration {
+	return cfg.Runner.Interval
+}
+
+func (cfg Global) RequestTimeout() time.Duration {
+	return cfg.Runner.RequestTimeout
+}
+
+func (cfg Global) GlobalTimeout() time.Duration {
+	return cfg.Runner.GlobalTimeout
 }
 
 // Default returns a default config that is safe to use.

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,19 @@ func (r Request) HTTP() (*http.Request, error) {
 	return req, nil
 }
 
+// WithURL sets the current Request with the parsed *url.URL from rawURL
+// and returns it. Any errors is discarded as a Config can be invalid
+// until Config.Validate is called. The url is always non-nil.
+func (r Request) WithURL(rawURL string) Request {
+	// ignore err: a Config can be invalid at this point
+	urlURL, _ := url.ParseRequestURI(rawURL)
+	if urlURL == nil {
+		urlURL = &url.URL{}
+	}
+	r.URL = urlURL
+	return r
+}
+
 // Runner contains options relative to the runner.
 type Runner struct {
 	Requests       int
@@ -95,19 +108,6 @@ func (cfg *Global) overrideHeader(newHeader http.Header) {
 	for k, v := range newHeader {
 		cfg.Request.Header[k] = v
 	}
-}
-
-// WithURL sets the current Config to the parsed *url.URL from rawURL
-// and returns it. Any errors is discarded as a Config can be invalid
-// until Config.Validate is called. The url is guaranteed not to be nil.
-func (cfg Global) WithURL(rawURL string) Global {
-	// ignore err: a Config can be invalid at this point
-	urlURL, _ := url.ParseRequestURI(rawURL)
-	if urlURL == nil {
-		urlURL = &url.URL{}
-	}
-	cfg.Request.URL = urlURL
-	return cfg
 }
 
 // Validate returns the config and a not nil ErrInvalid if any of the fields provided by the user is not valid

--- a/config/config.go
+++ b/config/config.go
@@ -11,18 +11,18 @@ import (
 
 // Request contains the confing options relative to a single request.
 type Request struct {
-	Method  string
-	URL     *url.URL
-	Header  http.Header
-	Timeout time.Duration
+	Method string
+	URL    *url.URL
+	Header http.Header
 }
 
 // RunnerOptions contains options relative to the runner.
 type RunnerOptions struct {
-	Requests      int
-	Concurrency   int
-	Interval      time.Duration
-	GlobalTimeout time.Duration
+	Requests       int
+	Concurrency    int
+	Interval       time.Duration
+	RequestTimeout time.Duration
+	GlobalTimeout  time.Duration
 }
 
 // Config represents the configuration of the runner.
@@ -70,14 +70,14 @@ func (cfg Config) Override(c Config, fields ...string) Config {
 			cfg.Request.URL = c.Request.URL
 		case FieldHeader:
 			cfg.overrideHeader(c.Request.Header)
-		case FieldTimeout:
-			cfg.Request.Timeout = c.Request.Timeout
 		case FieldRequests:
 			cfg.RunnerOptions.Requests = c.RunnerOptions.Requests
 		case FieldConcurrency:
 			cfg.RunnerOptions.Concurrency = c.RunnerOptions.Concurrency
 		case FieldInterval:
 			cfg.RunnerOptions.Interval = c.RunnerOptions.Interval
+		case FieldRequestTimeout:
+			cfg.RunnerOptions.RequestTimeout = c.RunnerOptions.RequestTimeout
 		case FieldGlobalTimeout:
 			cfg.RunnerOptions.GlobalTimeout = c.RunnerOptions.GlobalTimeout
 		}
@@ -128,12 +128,12 @@ func (cfg Config) Validate() error { //nolint:gocognit
 		inputErrors = append(inputErrors, fmt.Errorf("-concurrency: must be > 0, we got %d", cfg.RunnerOptions.Concurrency))
 	}
 
-	if cfg.Request.Timeout < 0 {
-		inputErrors = append(inputErrors, fmt.Errorf("-timeout: must be > 0, we got %d", cfg.Request.Timeout))
-	}
-
 	if cfg.RunnerOptions.Interval < 0 {
 		inputErrors = append(inputErrors, fmt.Errorf("-interval: must be > 0, we got %d", cfg.RunnerOptions.Interval))
+	}
+
+	if cfg.RunnerOptions.RequestTimeout < 0 {
+		inputErrors = append(inputErrors, fmt.Errorf("-timeout: must be > 0, we got %d", cfg.RunnerOptions.RequestTimeout))
 	}
 
 	if cfg.RunnerOptions.GlobalTimeout < 0 {

--- a/config/config.go
+++ b/config/config.go
@@ -16,8 +16,8 @@ type Request struct {
 	Header http.Header
 }
 
-// RunnerOptions contains options relative to the runner.
-type RunnerOptions struct {
+// Runner contains options relative to the runner.
+type Runner struct {
 	Requests       int
 	Concurrency    int
 	Interval       time.Duration
@@ -28,8 +28,8 @@ type RunnerOptions struct {
 // Config represents the configuration of the runner.
 // It must be validated using Config.Validate before usage.
 type Config struct {
-	Request       Request
-	RunnerOptions RunnerOptions
+	Request Request
+	Runner  Runner
 }
 
 // String returns an indented JSON representation of Config
@@ -71,15 +71,15 @@ func (cfg Config) Override(c Config, fields ...string) Config {
 		case FieldHeader:
 			cfg.overrideHeader(c.Request.Header)
 		case FieldRequests:
-			cfg.RunnerOptions.Requests = c.RunnerOptions.Requests
+			cfg.Runner.Requests = c.Runner.Requests
 		case FieldConcurrency:
-			cfg.RunnerOptions.Concurrency = c.RunnerOptions.Concurrency
+			cfg.Runner.Concurrency = c.Runner.Concurrency
 		case FieldInterval:
-			cfg.RunnerOptions.Interval = c.RunnerOptions.Interval
+			cfg.Runner.Interval = c.Runner.Interval
 		case FieldRequestTimeout:
-			cfg.RunnerOptions.RequestTimeout = c.RunnerOptions.RequestTimeout
+			cfg.Runner.RequestTimeout = c.Runner.RequestTimeout
 		case FieldGlobalTimeout:
-			cfg.RunnerOptions.GlobalTimeout = c.RunnerOptions.GlobalTimeout
+			cfg.Runner.GlobalTimeout = c.Runner.GlobalTimeout
 		}
 	}
 	return cfg
@@ -120,24 +120,24 @@ func (cfg Config) Validate() error { //nolint:gocognit
 		inputErrors = append(inputErrors, fmt.Errorf("-url: %s is not a valid url", cfg.Request.URL.String()))
 	}
 
-	if cfg.RunnerOptions.Requests < 1 && cfg.RunnerOptions.Requests != -1 {
-		inputErrors = append(inputErrors, fmt.Errorf("-requests: must be >= 0, we got %d", cfg.RunnerOptions.Requests))
+	if cfg.Runner.Requests < 1 && cfg.Runner.Requests != -1 {
+		inputErrors = append(inputErrors, fmt.Errorf("-requests: must be >= 0, we got %d", cfg.Runner.Requests))
 	}
 
-	if cfg.RunnerOptions.Concurrency < 1 && cfg.RunnerOptions.Concurrency != -1 {
-		inputErrors = append(inputErrors, fmt.Errorf("-concurrency: must be > 0, we got %d", cfg.RunnerOptions.Concurrency))
+	if cfg.Runner.Concurrency < 1 && cfg.Runner.Concurrency != -1 {
+		inputErrors = append(inputErrors, fmt.Errorf("-concurrency: must be > 0, we got %d", cfg.Runner.Concurrency))
 	}
 
-	if cfg.RunnerOptions.Interval < 0 {
-		inputErrors = append(inputErrors, fmt.Errorf("-interval: must be > 0, we got %d", cfg.RunnerOptions.Interval))
+	if cfg.Runner.Interval < 0 {
+		inputErrors = append(inputErrors, fmt.Errorf("-interval: must be > 0, we got %d", cfg.Runner.Interval))
 	}
 
-	if cfg.RunnerOptions.RequestTimeout < 0 {
-		inputErrors = append(inputErrors, fmt.Errorf("-timeout: must be > 0, we got %d", cfg.RunnerOptions.RequestTimeout))
+	if cfg.Runner.RequestTimeout < 0 {
+		inputErrors = append(inputErrors, fmt.Errorf("-timeout: must be > 0, we got %d", cfg.Runner.RequestTimeout))
 	}
 
-	if cfg.RunnerOptions.GlobalTimeout < 0 {
-		inputErrors = append(inputErrors, fmt.Errorf("-globalTimeout: must be > 0, we got %d", cfg.RunnerOptions.GlobalTimeout))
+	if cfg.Runner.GlobalTimeout < 0 {
+		inputErrors = append(inputErrors, fmt.Errorf("-globalTimeout: must be > 0, we got %d", cfg.Runner.GlobalTimeout))
 	}
 
 	if len(inputErrors) > 0 {

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,25 @@ type Request struct {
 	Header http.Header
 }
 
+// HTTP generates a *http.Request based on Request and returns it
+// or any non-nil error that occurred.
+func (r Request) HTTP() (*http.Request, error) {
+	if r.URL == nil {
+		return nil, errors.New("empty url")
+	}
+	rawURL := r.URL.String()
+	if _, err := url.ParseRequestURI(rawURL); err != nil {
+		return nil, errors.New("bad url")
+	}
+	// TODO: handle body
+	req, err := http.NewRequest(r.Method, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header = r.Header
+	return req, nil
+}
+
 // Runner contains options relative to the runner.
 type Runner struct {
 	Requests       int
@@ -37,25 +56,6 @@ type Global struct {
 func (cfg Global) String() string {
 	b, _ := json.MarshalIndent(cfg, "", "  ")
 	return string(b)
-}
-
-// HTTPRequest returns a *http.Request created from Target. Returns any non-nil
-// error that occurred.
-func (cfg Global) HTTPRequest() (*http.Request, error) {
-	if cfg.Request.URL == nil {
-		return nil, errors.New("empty url")
-	}
-	rawURL := cfg.Request.URL.String()
-	if _, err := url.ParseRequestURI(rawURL); err != nil {
-		return nil, errors.New("bad url")
-	}
-	// TODO: handle body
-	req, err := http.NewRequest(cfg.Request.Method, rawURL, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header = cfg.Request.Header
-	return req, nil
 }
 
 // Override returns a new Config based on cfg with overridden values from c.

--- a/config/config.go
+++ b/config/config.go
@@ -16,9 +16,9 @@ type Request struct {
 	Header http.Header
 }
 
-// HTTP generates a *http.Request based on Request and returns it
+// Value generates a *http.Request based on Request and returns it
 // or any non-nil error that occurred.
-func (r Request) HTTP() (*http.Request, error) {
+func (r Request) Value() (*http.Request, error) {
 	if r.URL == nil {
 		return nil, errors.New("empty url")
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 )
 
@@ -175,38 +174,4 @@ func (cfg Global) Validate() error { //nolint:gocognit
 // Default returns a default config that is safe to use.
 func Default() Global {
 	return defaultConfig
-}
-
-// ParseBodyContent parses raw and returns the content as a string or an error.
-// raw is in format "type:content", where type may be "raw" or "file".
-//
-// If type is "raw", content is the data as a string.
-//	"raw:{\"key\":\"value\"}" // escaped JSON
-//	"raw:text" // plain text
-// If type is "file", content is the path to the file holding the data.
-//	"file:./path/to/file.txt"
-//
-// Note: only type "raw" is supported at the moment.
-func ParseBody(raw string) (Body, error) {
-	if raw == "" {
-		// Body is nil.
-		return Body{}, nil
-	}
-
-	split := strings.SplitN(raw, ":", 2)
-	if len(split) != 2 {
-		return Body{}, fmt.Errorf("expected format \"<type>:<content>\", got %s", raw)
-	}
-	if split[1] == "" {
-		return Body{}, errors.New("got type but no content")
-	}
-
-	switch split[0] {
-	case "raw":
-		return NewBody("raw", split[1]), nil
-	// case "file":
-	// 	// TODO
-	default:
-		return Body{}, fmt.Errorf("unsupported type %s", split[0])
-	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -14,13 +14,14 @@ import (
 func TestValidate(t *testing.T) {
 	t.Run("test valid configuration", func(t *testing.T) {
 		cfg := config.Global{
+			Request: config.Request{}.WithURL("https://github.com/benchttp/"),
 			Runner: config.Runner{
 				Requests:       5,
 				Concurrency:    5,
 				RequestTimeout: 5,
 				GlobalTimeout:  5,
 			},
-		}.WithURL("https://github.com/benchttp/")
+		}
 		err := cfg.Validate()
 		if err != nil {
 			t.Errorf("valid configuration not considered as such")
@@ -29,13 +30,14 @@ func TestValidate(t *testing.T) {
 
 	t.Run("test invalid configuration returns ErrInvalid error with correct messages", func(t *testing.T) {
 		cfg := config.Global{
+			Request: config.Request{}.WithURL("github-com/benchttp"),
 			Runner: config.Runner{
 				Requests:       -5,
 				Concurrency:    -5,
 				RequestTimeout: -5,
 				GlobalTimeout:  -5,
 			},
-		}.WithURL("github-com/benchttp")
+		}
 		err := cfg.Validate()
 		if err == nil {
 			t.Errorf("invalid configuration considered valid")
@@ -61,7 +63,7 @@ func TestValidate(t *testing.T) {
 
 func TestWithURL(t *testing.T) {
 	t.Run("set empty url if invalid", func(t *testing.T) {
-		cfg := config.Global{}.WithURL("abc")
+		cfg := config.Global{Request: config.Request{}.WithURL("abc")}
 		if got := cfg.Request.URL; !reflect.DeepEqual(got, &url.URL{}) {
 			t.Errorf("exp empty *url.URL, got %v", got)
 		}
@@ -71,7 +73,7 @@ func TestWithURL(t *testing.T) {
 		var (
 			rawURL    = "http://benchttp.app?cool=true"
 			expURL, _ = url.ParseRequestURI(rawURL)
-			gotURL    = config.Global{}.WithURL(rawURL).Request.URL
+			gotURL    = config.Request{}.WithURL(rawURL).URL
 		)
 
 		if !reflect.DeepEqual(gotURL, expURL) {
@@ -84,13 +86,14 @@ func TestOverride(t *testing.T) {
 	t.Run("do not override unspecified fields", func(t *testing.T) {
 		baseCfg := config.Global{}
 		newCfg := config.Global{
+			Request: config.Request{}.WithURL("http://a.b?p=2"),
 			Runner: config.Runner{
 				Requests:       1,
 				Concurrency:    2,
 				RequestTimeout: 3 * time.Second,
 				GlobalTimeout:  4 * time.Second,
 			},
-		}.WithURL("http://a.b?p=2")
+		}
 
 		if gotCfg := baseCfg.Override(newCfg); !reflect.DeepEqual(gotCfg, baseCfg) {
 			t.Errorf("overrode unexpected fields:\nexp %#v\ngot %#v", baseCfg, gotCfg)
@@ -100,13 +103,14 @@ func TestOverride(t *testing.T) {
 	t.Run("override specified fields", func(t *testing.T) {
 		baseCfg := config.Global{}
 		newCfg := config.Global{
+			Request: config.Request{}.WithURL("http://a.b?p=2"),
 			Runner: config.Runner{
 				Requests:       1,
 				Concurrency:    2,
 				RequestTimeout: 3 * time.Second,
 				GlobalTimeout:  4 * time.Second,
 			},
-		}.WithURL("http://a.b?p=2")
+		}
 		fields := []string{
 			config.FieldMethod,
 			config.FieldURL,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -14,13 +14,11 @@ import (
 func TestValidate(t *testing.T) {
 	t.Run("test valid configuration", func(t *testing.T) {
 		cfg := config.Config{
-			Request: config.Request{
-				Timeout: 5,
-			},
 			RunnerOptions: config.RunnerOptions{
-				Requests:      5,
-				Concurrency:   5,
-				GlobalTimeout: 5,
+				Requests:       5,
+				Concurrency:    5,
+				RequestTimeout: 5,
+				GlobalTimeout:  5,
 			},
 		}.WithURL("https://github.com/benchttp/")
 		err := cfg.Validate()
@@ -31,13 +29,11 @@ func TestValidate(t *testing.T) {
 
 	t.Run("test invalid configuration returns ErrInvalid error with correct messages", func(t *testing.T) {
 		cfg := config.Config{
-			Request: config.Request{
-				Timeout: -5,
-			},
 			RunnerOptions: config.RunnerOptions{
-				Requests:      -5,
-				Concurrency:   -5,
-				GlobalTimeout: -5,
+				Requests:       -5,
+				Concurrency:    -5,
+				RequestTimeout: -5,
+				GlobalTimeout:  -5,
 			},
 		}.WithURL("github-com/benchttp")
 		err := cfg.Validate()
@@ -88,13 +84,11 @@ func TestOverride(t *testing.T) {
 	t.Run("do not override unspecified fields", func(t *testing.T) {
 		baseCfg := config.Config{}
 		newCfg := config.Config{
-			Request: config.Request{
-				Timeout: 3 * time.Second,
-			},
 			RunnerOptions: config.RunnerOptions{
-				Requests:      1,
-				Concurrency:   2,
-				GlobalTimeout: 4 * time.Second,
+				Requests:       1,
+				Concurrency:    2,
+				RequestTimeout: 3 * time.Second,
+				GlobalTimeout:  4 * time.Second,
 			},
 		}.WithURL("http://a.b?p=2")
 
@@ -106,21 +100,19 @@ func TestOverride(t *testing.T) {
 	t.Run("override specified fields", func(t *testing.T) {
 		baseCfg := config.Config{}
 		newCfg := config.Config{
-			Request: config.Request{
-				Timeout: 3 * time.Second,
-			},
 			RunnerOptions: config.RunnerOptions{
-				Requests:      1,
-				Concurrency:   2,
-				GlobalTimeout: 4 * time.Second,
+				Requests:       1,
+				Concurrency:    2,
+				RequestTimeout: 3 * time.Second,
+				GlobalTimeout:  4 * time.Second,
 			},
 		}.WithURL("http://a.b?p=2")
 		fields := []string{
 			config.FieldMethod,
 			config.FieldURL,
-			config.FieldTimeout,
 			config.FieldRequests,
 			config.FieldConcurrency,
+			config.FieldRequestTimeout,
 			config.FieldGlobalTimeout,
 		}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -14,7 +14,7 @@ import (
 func TestValidate(t *testing.T) {
 	t.Run("test valid configuration", func(t *testing.T) {
 		cfg := config.Config{
-			RunnerOptions: config.RunnerOptions{
+			Runner: config.Runner{
 				Requests:       5,
 				Concurrency:    5,
 				RequestTimeout: 5,
@@ -29,7 +29,7 @@ func TestValidate(t *testing.T) {
 
 	t.Run("test invalid configuration returns ErrInvalid error with correct messages", func(t *testing.T) {
 		cfg := config.Config{
-			RunnerOptions: config.RunnerOptions{
+			Runner: config.Runner{
 				Requests:       -5,
 				Concurrency:    -5,
 				RequestTimeout: -5,
@@ -84,7 +84,7 @@ func TestOverride(t *testing.T) {
 	t.Run("do not override unspecified fields", func(t *testing.T) {
 		baseCfg := config.Config{}
 		newCfg := config.Config{
-			RunnerOptions: config.RunnerOptions{
+			Runner: config.Runner{
 				Requests:       1,
 				Concurrency:    2,
 				RequestTimeout: 3 * time.Second,
@@ -100,7 +100,7 @@ func TestOverride(t *testing.T) {
 	t.Run("override specified fields", func(t *testing.T) {
 		baseCfg := config.Config{}
 		newCfg := config.Config{
-			RunnerOptions: config.RunnerOptions{
+			Runner: config.Runner{
 				Requests:       1,
 				Concurrency:    2,
 				RequestTimeout: 3 * time.Second,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestValidate(t *testing.T) {
 	t.Run("test valid configuration", func(t *testing.T) {
-		cfg := config.Config{
+		cfg := config.Global{
 			Runner: config.Runner{
 				Requests:       5,
 				Concurrency:    5,
@@ -28,7 +28,7 @@ func TestValidate(t *testing.T) {
 	})
 
 	t.Run("test invalid configuration returns ErrInvalid error with correct messages", func(t *testing.T) {
-		cfg := config.Config{
+		cfg := config.Global{
 			Runner: config.Runner{
 				Requests:       -5,
 				Concurrency:    -5,
@@ -61,7 +61,7 @@ func TestValidate(t *testing.T) {
 
 func TestWithURL(t *testing.T) {
 	t.Run("set empty url if invalid", func(t *testing.T) {
-		cfg := config.Config{}.WithURL("abc")
+		cfg := config.Global{}.WithURL("abc")
 		if got := cfg.Request.URL; !reflect.DeepEqual(got, &url.URL{}) {
 			t.Errorf("exp empty *url.URL, got %v", got)
 		}
@@ -71,7 +71,7 @@ func TestWithURL(t *testing.T) {
 		var (
 			rawURL    = "http://benchttp.app?cool=true"
 			expURL, _ = url.ParseRequestURI(rawURL)
-			gotURL    = config.Config{}.WithURL(rawURL).Request.URL
+			gotURL    = config.Global{}.WithURL(rawURL).Request.URL
 		)
 
 		if !reflect.DeepEqual(gotURL, expURL) {
@@ -82,8 +82,8 @@ func TestWithURL(t *testing.T) {
 
 func TestOverride(t *testing.T) {
 	t.Run("do not override unspecified fields", func(t *testing.T) {
-		baseCfg := config.Config{}
-		newCfg := config.Config{
+		baseCfg := config.Global{}
+		newCfg := config.Global{
 			Runner: config.Runner{
 				Requests:       1,
 				Concurrency:    2,
@@ -98,8 +98,8 @@ func TestOverride(t *testing.T) {
 	})
 
 	t.Run("override specified fields", func(t *testing.T) {
-		baseCfg := config.Config{}
-		newCfg := config.Config{
+		baseCfg := config.Global{}
+		newCfg := config.Global{
 			Runner: config.Runner{
 				Requests:       1,
 				Concurrency:    2,
@@ -188,13 +188,13 @@ func TestOverride(t *testing.T) {
 
 		for _, tc := range testcases {
 			t.Run(tc.label, func(t *testing.T) {
-				oldCfg := config.Config{
+				oldCfg := config.Global{
 					Request: config.Request{
 						Header: tc.oldHeader,
 					},
 				}
 
-				newCfg := config.Config{
+				newCfg := config.Global{
 					Request: config.Request{
 						Header: tc.newHeader,
 					},

--- a/config/default.go
+++ b/config/default.go
@@ -10,7 +10,7 @@ var defaultConfig = Config{
 		Method: "GET",
 		URL:    &url.URL{},
 	},
-	RunnerOptions: RunnerOptions{
+	Runner: Runner{
 		Concurrency:    1,
 		Requests:       -1, // Use GlobalTimeout as exit condition.
 		RequestTimeout: 10 * time.Second,

--- a/config/default.go
+++ b/config/default.go
@@ -7,13 +7,13 @@ import (
 
 var defaultConfig = Config{
 	Request: Request{
-		Method:  "GET",
-		URL:     &url.URL{},
-		Timeout: 10 * time.Second,
+		Method: "GET",
+		URL:    &url.URL{},
 	},
 	RunnerOptions: RunnerOptions{
-		Concurrency:   1,
-		Requests:      -1, // Use GlobalTimeout as exit condition.
-		GlobalTimeout: 30 * time.Second,
+		Concurrency:    1,
+		Requests:       -1, // Use GlobalTimeout as exit condition.
+		RequestTimeout: 10 * time.Second,
+		GlobalTimeout:  30 * time.Second,
 	},
 }

--- a/config/default.go
+++ b/config/default.go
@@ -1,18 +1,21 @@
 package config
 
 import (
+	"net/http"
 	"net/url"
 	"time"
 )
 
-var defaultConfig = Config{
+var defaultConfig = Global{
 	Request: Request{
 		Method: "GET",
 		URL:    &url.URL{},
+		Header: http.Header{},
 	},
 	Runner: Runner{
 		Concurrency:    1,
 		Requests:       -1, // Use GlobalTimeout as exit condition.
+		Interval:       0 * time.Second,
 		RequestTimeout: 10 * time.Second,
 		GlobalTimeout:  30 * time.Second,
 	},

--- a/config/field.go
+++ b/config/field.go
@@ -1,20 +1,20 @@
 package config
 
 const (
-	FieldMethod        = "method"
-	FieldURL           = "url"
-	FieldHeader        = "header"
-	FieldTimeout       = "timeout"
-	FieldRequests      = "requests"
-	FieldConcurrency   = "concurrency"
-	FieldInterval      = "interval"
-	FieldGlobalTimeout = "globalTimeout"
+	FieldMethod         = "method"
+	FieldURL            = "url"
+	FieldHeader         = "header"
+	FieldRequests       = "requests"
+	FieldConcurrency    = "concurrency"
+	FieldInterval       = "interval"
+	FieldRequestTimeout = "requestTimeout"
+	FieldGlobalTimeout  = "globalTimeout"
 )
 
 func IsField(v string) bool {
 	switch v {
-	case FieldMethod, FieldURL, FieldHeader, FieldTimeout,
-		FieldRequests, FieldConcurrency, FieldInterval,
+	case FieldMethod, FieldURL, FieldHeader, FieldRequests,
+		FieldConcurrency, FieldInterval, FieldRequestTimeout,
 		FieldGlobalTimeout:
 		return true
 	}

--- a/config/field_test.go
+++ b/config/field_test.go
@@ -13,9 +13,10 @@ func TestIsField(t *testing.T) {
 		{In: config.FieldMethod, Exp: true},
 		{In: config.FieldURL, Exp: true},
 		{In: config.FieldHeader, Exp: true},
-		{In: config.FieldTimeout, Exp: true},
-		{In: config.FieldConcurrency, Exp: true},
 		{In: config.FieldRequests, Exp: true},
+		{In: config.FieldConcurrency, Exp: true},
+		{In: config.FieldInterval, Exp: true},
+		{In: config.FieldRequestTimeout, Exp: true},
 		{In: config.FieldGlobalTimeout, Exp: true},
 		{In: "notafield", Exp: false},
 	}).Run(t)

--- a/config/file/parse.go
+++ b/config/file/parse.go
@@ -71,15 +71,6 @@ func parseRawConfig(raw unmarshaledConfig) (config.Config, error) { //nolint:goc
 		fields = append(fields, config.FieldHeader)
 	}
 
-	if timeout := raw.Request.Timeout; timeout != nil {
-		parsedTimeout, err := parseOptionalDuration(*timeout)
-		if err != nil {
-			return config.Config{}, err
-		}
-		cfg.Request.Timeout = parsedTimeout
-		fields = append(fields, config.FieldTimeout)
-	}
-
 	if requests := raw.RunnerOptions.Requests; requests != nil {
 		cfg.RunnerOptions.Requests = *requests
 		fields = append(fields, config.FieldRequests)
@@ -97,6 +88,15 @@ func parseRawConfig(raw unmarshaledConfig) (config.Config, error) { //nolint:goc
 		}
 		cfg.RunnerOptions.Interval = parsedInterval
 		fields = append(fields, config.FieldInterval)
+	}
+
+	if requestTimeout := raw.RunnerOptions.RequestTimeout; requestTimeout != nil {
+		parsedTimeout, err := parseOptionalDuration(*requestTimeout)
+		if err != nil {
+			return config.Config{}, err
+		}
+		cfg.RunnerOptions.RequestTimeout = parsedTimeout
+		fields = append(fields, config.FieldRequestTimeout)
 	}
 
 	if globalTimeout := raw.RunnerOptions.GlobalTimeout; globalTimeout != nil {

--- a/config/file/parse.go
+++ b/config/file/parse.go
@@ -71,40 +71,40 @@ func parseRawConfig(raw unmarshaledConfig) (config.Config, error) { //nolint:goc
 		fields = append(fields, config.FieldHeader)
 	}
 
-	if requests := raw.RunnerOptions.Requests; requests != nil {
-		cfg.RunnerOptions.Requests = *requests
+	if requests := raw.Runner.Requests; requests != nil {
+		cfg.Runner.Requests = *requests
 		fields = append(fields, config.FieldRequests)
 	}
 
-	if concurrency := raw.RunnerOptions.Concurrency; concurrency != nil {
-		cfg.RunnerOptions.Concurrency = *concurrency
+	if concurrency := raw.Runner.Concurrency; concurrency != nil {
+		cfg.Runner.Concurrency = *concurrency
 		fields = append(fields, config.FieldConcurrency)
 	}
 
-	if interval := raw.RunnerOptions.Interval; interval != nil {
+	if interval := raw.Runner.Interval; interval != nil {
 		parsedInterval, err := parseOptionalDuration(*interval)
 		if err != nil {
 			return config.Config{}, err
 		}
-		cfg.RunnerOptions.Interval = parsedInterval
+		cfg.Runner.Interval = parsedInterval
 		fields = append(fields, config.FieldInterval)
 	}
 
-	if requestTimeout := raw.RunnerOptions.RequestTimeout; requestTimeout != nil {
+	if requestTimeout := raw.Runner.RequestTimeout; requestTimeout != nil {
 		parsedTimeout, err := parseOptionalDuration(*requestTimeout)
 		if err != nil {
 			return config.Config{}, err
 		}
-		cfg.RunnerOptions.RequestTimeout = parsedTimeout
+		cfg.Runner.RequestTimeout = parsedTimeout
 		fields = append(fields, config.FieldRequestTimeout)
 	}
 
-	if globalTimeout := raw.RunnerOptions.GlobalTimeout; globalTimeout != nil {
+	if globalTimeout := raw.Runner.GlobalTimeout; globalTimeout != nil {
 		parsedGlobalTimeout, err := parseOptionalDuration(*globalTimeout)
 		if err != nil {
 			return config.Config{}, err
 		}
-		cfg.RunnerOptions.GlobalTimeout = parsedGlobalTimeout
+		cfg.Runner.GlobalTimeout = parsedGlobalTimeout
 		fields = append(fields, config.FieldGlobalTimeout)
 	}
 

--- a/config/file/parse.go
+++ b/config/file/parse.go
@@ -13,7 +13,7 @@ import (
 
 // Parse parses a benchttp runner config file into a config.Config
 // and returns it or the first non-nil error occurring in the process.
-func Parse(cfgpath string) (cfg config.Config, err error) {
+func Parse(cfgpath string) (cfg config.Global, err error) {
 	b, err := os.ReadFile(cfgpath)
 	switch {
 	case err == nil:
@@ -44,8 +44,8 @@ func Parse(cfgpath string) (cfg config.Config, err error) {
 
 // parseRawConfig parses an input raw config as a config.Config and returns it
 // or the first non-nil error occurring in the process.
-func parseRawConfig(raw unmarshaledConfig) (config.Config, error) { //nolint:gocognit // acceptable complexity for a parsing func
-	cfg := config.Config{}
+func parseRawConfig(raw unmarshaledConfig) (config.Global, error) { //nolint:gocognit // acceptable complexity for a parsing func
+	cfg := config.Global{}
 	fields := make([]string, 0, 6)
 
 	if method := raw.Request.Method; method != nil {
@@ -56,7 +56,7 @@ func parseRawConfig(raw unmarshaledConfig) (config.Config, error) { //nolint:goc
 	if rawURL := raw.Request.URL; rawURL != nil {
 		parsedURL, err := parseAndBuildURL(*raw.Request.URL, raw.Request.QueryParams)
 		if err != nil {
-			return config.Config{}, err
+			return config.Global{}, err
 		}
 		cfg.Request.URL = parsedURL
 		fields = append(fields, config.FieldURL)
@@ -84,7 +84,7 @@ func parseRawConfig(raw unmarshaledConfig) (config.Config, error) { //nolint:goc
 	if interval := raw.Runner.Interval; interval != nil {
 		parsedInterval, err := parseOptionalDuration(*interval)
 		if err != nil {
-			return config.Config{}, err
+			return config.Global{}, err
 		}
 		cfg.Runner.Interval = parsedInterval
 		fields = append(fields, config.FieldInterval)
@@ -93,7 +93,7 @@ func parseRawConfig(raw unmarshaledConfig) (config.Config, error) { //nolint:goc
 	if requestTimeout := raw.Runner.RequestTimeout; requestTimeout != nil {
 		parsedTimeout, err := parseOptionalDuration(*requestTimeout)
 		if err != nil {
-			return config.Config{}, err
+			return config.Global{}, err
 		}
 		cfg.Runner.RequestTimeout = parsedTimeout
 		fields = append(fields, config.FieldRequestTimeout)
@@ -102,7 +102,7 @@ func parseRawConfig(raw unmarshaledConfig) (config.Config, error) { //nolint:goc
 	if globalTimeout := raw.Runner.GlobalTimeout; globalTimeout != nil {
 		parsedGlobalTimeout, err := parseOptionalDuration(*globalTimeout)
 		if err != nil {
-			return config.Config{}, err
+			return config.Global{}, err
 		}
 		cfg.Runner.GlobalTimeout = parsedGlobalTimeout
 		fields = append(fields, config.FieldGlobalTimeout)

--- a/config/file/parse_test.go
+++ b/config/file/parse_test.go
@@ -144,14 +144,14 @@ func newExpConfig() config.Config {
 				"key0": []string{"val0", "val1"},
 				"key1": []string{"val0"},
 			},
-			Timeout: 2 * time.Second,
 		},
 
 		RunnerOptions: config.RunnerOptions{
-			Requests:      100,
-			Concurrency:   1,
-			Interval:      50 * time.Millisecond,
-			GlobalTimeout: 60 * time.Second,
+			Requests:       100,
+			Concurrency:    1,
+			Interval:       50 * time.Millisecond,
+			RequestTimeout: 2 * time.Second,
+			GlobalTimeout:  60 * time.Second,
 		},
 	}
 }

--- a/config/file/parse_test.go
+++ b/config/file/parse_test.go
@@ -118,11 +118,11 @@ func TestParse(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if gotRequests := cfg.RunnerOptions.Requests; gotRequests != expRequests {
+		if gotRequests := cfg.Runner.Requests; gotRequests != expRequests {
 			t.Errorf("did not override Requests: exp %d, got %d", expRequests, gotRequests)
 		}
 
-		if gotGlobalTimeout := cfg.RunnerOptions.GlobalTimeout; gotGlobalTimeout != expGlobalTimeout {
+		if gotGlobalTimeout := cfg.Runner.GlobalTimeout; gotGlobalTimeout != expGlobalTimeout {
 			t.Errorf("did not override GlobalTimeout: exp %d, got %d", expGlobalTimeout, gotGlobalTimeout)
 		}
 
@@ -146,7 +146,7 @@ func newExpConfig() config.Config {
 			},
 		},
 
-		RunnerOptions: config.RunnerOptions{
+		Runner: config.Runner{
 			Requests:       100,
 			Concurrency:    1,
 			Interval:       50 * time.Millisecond,

--- a/config/file/parse_test.go
+++ b/config/file/parse_test.go
@@ -66,7 +66,7 @@ func TestParse(t *testing.T) {
 					t.Errorf("\nexp %v\ngot %v", tc.expErr, gotErr)
 				}
 
-				if !reflect.DeepEqual(gotCfg, config.Config{}) {
+				if !reflect.DeepEqual(gotCfg, config.Global{}) {
 					t.Errorf("\nexp config.Config{}\ngot %v", gotCfg)
 				}
 			})
@@ -134,9 +134,9 @@ func TestParse(t *testing.T) {
 
 // newExpConfig returns the expected config.Config result after parsing
 // one of the config files in testdataConfigPath.
-func newExpConfig() config.Config {
+func newExpConfig() config.Global {
 	u, _ := url.ParseRequestURI(testURL)
-	return config.Config{
+	return config.Global{
 		Request: config.Request{
 			Method: "GET",
 			URL:    u,

--- a/config/file/parser.go
+++ b/config/file/parser.go
@@ -193,11 +193,11 @@ type unmarshaledConfig struct {
 		Header      map[string][]string `yaml:"header" json:"header"`
 	} `yaml:"request" json:"request"`
 
-	RunnerOptions struct {
+	Runner struct {
 		Requests       *int    `yaml:"requests" json:"requests"`
 		Concurrency    *int    `yaml:"concurrency" json:"concurrency"`
 		Interval       *string `yaml:"interval" json:"interval"`
 		RequestTimeout *string `yaml:"requestTimeout" json:"requestTimeout"`
 		GlobalTimeout  *string `yaml:"globalTimeout" json:"globalTimeout"`
-	} `yaml:"runnerOptions" json:"runnerOptions"`
+	} `yaml:"runner" json:"runner"`
 }

--- a/config/file/parser.go
+++ b/config/file/parser.go
@@ -191,13 +191,13 @@ type unmarshaledConfig struct {
 		URL         *string             `yaml:"url" json:"url"`
 		QueryParams map[string]string   `yaml:"queryParams" json:"queryParams"`
 		Header      map[string][]string `yaml:"header" json:"header"`
-		Timeout     *string             `yaml:"timeout" json:"timeout"`
 	} `yaml:"request" json:"request"`
 
 	RunnerOptions struct {
-		Requests      *int    `yaml:"requests" json:"requests"`
-		Concurrency   *int    `yaml:"concurrency" json:"concurrency"`
-		Interval      *string `yaml:"interval" json:"interval"`
-		GlobalTimeout *string `yaml:"globalTimeout" json:"globalTimeout"`
+		Requests       *int    `yaml:"requests" json:"requests"`
+		Concurrency    *int    `yaml:"concurrency" json:"concurrency"`
+		Interval       *string `yaml:"interval" json:"interval"`
+		RequestTimeout *string `yaml:"requestTimeout" json:"requestTimeout"`
+		GlobalTimeout  *string `yaml:"globalTimeout" json:"globalTimeout"`
 	} `yaml:"runnerOptions" json:"runnerOptions"`
 }

--- a/config/file/parser_internal_test.go
+++ b/config/file/parser_internal_test.go
@@ -26,7 +26,7 @@ func TestYAMLParser(t *testing.T) {
 			},
 			{
 				label: "wrong type unknown value",
-				in:    []byte("runnerOptions:\n  requests: [123]\n"),
+				in:    []byte("runner:\n  requests: [123]\n"),
 				expErr: &yaml.TypeError{
 					Errors: []string{
 						`line 2: wrong type: want int`,
@@ -35,7 +35,7 @@ func TestYAMLParser(t *testing.T) {
 			},
 			{
 				label: "wrong type known value",
-				in:    []byte("runnerOptions:\n  requests: \"123\"\n"),
+				in:    []byte("runner:\n  requests: \"123\"\n"),
 				expErr: &yaml.TypeError{
 					Errors: []string{
 						`line 2: wrong type ("123"): want int`,
@@ -44,7 +44,7 @@ func TestYAMLParser(t *testing.T) {
 			},
 			{
 				label: "cumulate errors",
-				in:    []byte("runnerOptions:\n  requests: [123]\n  concurrency: \"123\"\nnotafield: 123\n"),
+				in:    []byte("runner:\n  requests: [123]\n  concurrency: \"123\"\nnotafield: 123\n"),
 				expErr: &yaml.TypeError{
 					Errors: []string{
 						`line 2: wrong type: want int`,
@@ -55,7 +55,7 @@ func TestYAMLParser(t *testing.T) {
 			},
 			{
 				label:  "no errors custom fields",
-				in:     []byte("x-data: &count\n  requests: 100\nrunnerOptions:\n  <<: *count\n"),
+				in:     []byte("x-data: &count\n  requests: 100\rrunner:\n  <<: *count\n"),
 				expErr: nil,
 			},
 		}
@@ -98,8 +98,8 @@ func TestJSONParser(t *testing.T) {
 		}{
 			{
 				label: "syntax error",
-				in:    []byte("{\n  \"runnerOptions\": {},\n}\n"),
-				exp:   "syntax error near 26: invalid character '}' looking for beginning of object key string",
+				in:    []byte("{\n  \"runner\": {},\n}\n"),
+				exp:   "syntax error near 19: invalid character '}' looking for beginning of object key string",
 			},
 			{
 				label: "unknown field",
@@ -108,12 +108,12 @@ func TestJSONParser(t *testing.T) {
 			},
 			{
 				label: "wrong type",
-				in:    []byte("{\n  \"runnerOptions\": {\n    \"requests\": [123]\n  }\n}\n"),
-				exp:   "wrong type for field runnerOptions.requests: want int, got array",
+				in:    []byte("{\n  \"runner\": {\n    \"requests\": [123]\n  }\n}\n"),
+				exp:   "wrong type for field runner.requests: want int, got array",
 			},
 			{
 				label: "valid config",
-				in:    []byte("{\n  \"runnerOptions\": {\n    \"requests\": 123\n  }\n}\n"),
+				in:    []byte("{\n  \"runner\": {\n    \"requests\": 123\n  }\n}\n"),
 				exp:   "",
 			},
 		}

--- a/requester/error.go
+++ b/requester/error.go
@@ -3,9 +3,6 @@ package requester
 import "errors"
 
 var (
-	// ErrRequest is returned when an invalid *http.Request is generated
-	// by the Requester config.
-	ErrRequest = errors.New("invalid request")
 	// ErrConnection is returned when the Requester fails to connect to
 	// the requested URL.
 	ErrConnection = errors.New("connection error")

--- a/requester/print.go
+++ b/requester/print.go
@@ -24,8 +24,8 @@ func (r *Requester) state() state {
 		done:    r.done,
 		err:     r.runErr,
 		reqcur:  len(r.records),
-		reqmax:  r.config.RunnerOptions.Requests,
-		timeout: r.config.RunnerOptions.GlobalTimeout,
+		reqmax:  r.config.Requests,
+		timeout: r.config.GlobalTimeout,
 		elapsed: time.Since(r.start),
 	}
 }

--- a/requester/report.go
+++ b/requester/report.go
@@ -5,17 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-
-	"github.com/benchttp/runner/config"
 )
 
 // Report represents the collected results of a benchmark test.
 type Report struct {
-	Config  config.Config `json:"config"`
-	Records []Record      `json:"records"`
-	Length  int           `json:"length"`
-	Success int           `json:"success"`
-	Fail    int           `json:"fail"`
+	Records []Record `json:"records"`
+	Length  int      `json:"length"`
+	Success int      `json:"success"`
+	Fail    int      `json:"fail"`
 }
 
 func (rep Report) String() string {
@@ -24,9 +21,8 @@ func (rep Report) String() string {
 }
 
 // report generates and returns a Report from a previous Run.
-func makeReport(cfg config.Config, records []Record, numErr int) Report {
+func makeReport(records []Record, numErr int) Report {
 	return Report{
-		Config:  cfg,
 		Records: records,
 		Length:  len(records),
 		Success: len(records) - numErr,
@@ -34,8 +30,10 @@ func makeReport(cfg config.Config, records []Record, numErr int) Report {
 	}
 }
 
-// SendReport sends the report to url. Returns any non-nil error that occurred.
-func (r *Requester) SendReport(url string, report Report) error {
+// SendReport sends the report to url. Returns any non-nil error that occurred.;
+//
+// TODO: move from requester
+func SendReport(url string, report Report) error {
 	body := bytes.Buffer{}
 	if err := json.NewEncoder(&body).Encode(report); err != nil {
 		return fmt.Errorf("%w: %s", ErrReporting, err)
@@ -53,22 +51,6 @@ func (r *Requester) SendReport(url string, report Report) error {
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("%w: %s", ErrReporting, resp.Status)
-	}
-
-	return nil
-}
-
-// RunAndSendReport calls Run and then Report in a single
-// invocation. It's useful for simple usecases where the
-// caller don't need to known about the Report.
-func (r *Requester) RunAndSendReport(url string) error {
-	report, err := r.Run()
-	if err != nil {
-		return err
-	}
-
-	if err := r.SendReport(url, report); err != nil {
-		return err
 	}
 
 	return nil

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -47,7 +47,7 @@ func New(cfg config.Config) *Requester {
 			// Timeout includes connection time, any redirects, and reading
 			// the response body.
 			// We may want exclude reading the response body in our benchmark tool.
-			Timeout: cfg.Request.Timeout,
+			Timeout: cfg.RunnerOptions.RequestTimeout,
 
 			// tracer keeps track of all events of the current request.
 			Transport: tracer,

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -15,12 +15,12 @@ const (
 	defaultRecordsCap = 1000
 )
 
-type Config interface {
-	Requests() int
-	Concurrency() int
-	Interval() time.Duration
-	RequestTimeout() time.Duration
-	GlobalTimeout() time.Duration
+type Config struct {
+	Requests       int
+	Concurrency    int
+	Interval       time.Duration
+	RequestTimeout time.Duration
+	GlobalTimeout  time.Duration
 }
 
 // Requester executes the benchmark. It wraps http.Client.
@@ -39,7 +39,7 @@ type Requester struct {
 // it is the caller's responsibility to ensure cfg is valid using
 // cfg.Validate.
 func New(cfg Config) *Requester {
-	recordsCap := cfg.Requests()
+	recordsCap := cfg.Requests
 	if recordsCap < 1 {
 		recordsCap = defaultRecordsCap
 	}
@@ -54,7 +54,7 @@ func New(cfg Config) *Requester {
 			// Timeout includes connection time, any redirects, and reading
 			// the response body.
 			// We may want exclude reading the response body in our benchmark tool.
-			Timeout: cfg.RequestTimeout(),
+			Timeout: cfg.RequestTimeout,
 
 			// tracer keeps track of all events of the current request.
 			Transport: tracer,
@@ -70,10 +70,10 @@ func (r *Requester) Run(req *http.Request) (Report, error) {
 	}
 
 	var (
-		numWorker   = r.config.Concurrency()
-		maxIter     = r.config.Requests()
-		timeout     = r.config.GlobalTimeout()
-		interval    = r.config.Interval()
+		numWorker   = r.config.Concurrency
+		maxIter     = r.config.Requests
+		timeout     = r.config.GlobalTimeout
+		interval    = r.config.Interval
 		ctx, cancel = context.WithTimeout(context.Background(), timeout)
 	)
 

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -15,12 +15,12 @@ const (
 	defaultRecordsCap = 1000
 )
 
-type Config struct {
-	Requests       int
-	Concurrency    int
-	Interval       time.Duration
-	RequestTimeout time.Duration
-	GlobalTimeout  time.Duration
+type Config interface {
+	Requests() int
+	Concurrency() int
+	Interval() time.Duration
+	RequestTimeout() time.Duration
+	GlobalTimeout() time.Duration
 }
 
 // Requester executes the benchmark. It wraps http.Client.
@@ -39,7 +39,7 @@ type Requester struct {
 // it is the caller's responsibility to ensure cfg is valid using
 // cfg.Validate.
 func New(cfg Config) *Requester {
-	recordsCap := cfg.Requests
+	recordsCap := cfg.Requests()
 	if recordsCap < 1 {
 		recordsCap = defaultRecordsCap
 	}
@@ -54,7 +54,7 @@ func New(cfg Config) *Requester {
 			// Timeout includes connection time, any redirects, and reading
 			// the response body.
 			// We may want exclude reading the response body in our benchmark tool.
-			Timeout: cfg.RequestTimeout,
+			Timeout: cfg.RequestTimeout(),
 
 			// tracer keeps track of all events of the current request.
 			Transport: tracer,
@@ -70,10 +70,10 @@ func (r *Requester) Run(req *http.Request) (Report, error) {
 	}
 
 	var (
-		numWorker   = r.config.Concurrency
-		maxIter     = r.config.Requests
-		timeout     = r.config.GlobalTimeout
-		interval    = r.config.Interval
+		numWorker   = r.config.Concurrency()
+		maxIter     = r.config.Requests()
+		timeout     = r.config.GlobalTimeout()
+		interval    = r.config.Interval()
 		ctx, cancel = context.WithTimeout(context.Background(), timeout)
 	)
 

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -32,7 +32,7 @@ type Requester struct {
 // it is the caller's responsibility to ensure cfg is valid using
 // cfg.Validate.
 func New(cfg config.Config) *Requester {
-	recordsCap := cfg.RunnerOptions.Requests
+	recordsCap := cfg.Runner.Requests
 	if recordsCap < 1 {
 		recordsCap = defaultRecordsCap
 	}
@@ -47,7 +47,7 @@ func New(cfg config.Config) *Requester {
 			// Timeout includes connection time, any redirects, and reading
 			// the response body.
 			// We may want exclude reading the response body in our benchmark tool.
-			Timeout: cfg.RunnerOptions.RequestTimeout,
+			Timeout: cfg.Runner.RequestTimeout,
 
 			// tracer keeps track of all events of the current request.
 			Transport: tracer,
@@ -68,10 +68,10 @@ func (r *Requester) Run() (Report, error) {
 	}
 
 	var (
-		numWorker   = r.config.RunnerOptions.Concurrency
-		maxIter     = r.config.RunnerOptions.Requests
-		timeout     = r.config.RunnerOptions.GlobalTimeout
-		interval    = r.config.RunnerOptions.Interval
+		numWorker   = r.config.Runner.Concurrency
+		maxIter     = r.config.Runner.Requests
+		timeout     = r.config.Runner.GlobalTimeout
+		interval    = r.config.Runner.Interval
 		ctx, cancel = context.WithTimeout(context.Background(), timeout)
 	)
 

--- a/requester/requester_internal_test.go
+++ b/requester/requester_internal_test.go
@@ -21,23 +21,24 @@ func TestRun(t *testing.T) {
 	}{
 		{
 			label: "return ErrConnection early on connection error",
-			req: New(runnerConfig{
-				requests:       -1,
-				concurrency:    1,
-				requestTimeout: 1 * time.Second,
-				globalTimeout:  0,
+			req: New(Config{
+				Requests:       -1,
+				Concurrency:    1,
+				RequestTimeout: 1 * time.Second,
+				GlobalTimeout:  0,
 			},
 			),
 			exp: ErrConnection,
 		},
 		{
 			label: "return dispatcher.ErrInvalidValue early on bad dispatcher value",
-			req: withNoopTransport(New(runnerConfig{
-				requests:       1,
-				concurrency:    2, // bad: Concurrency > Requests
-				requestTimeout: 1 * time.Second,
-				globalTimeout:  3 * time.Second,
-			})),
+			req: withNoopTransport(New(Config{
+				Requests:       1,
+				Concurrency:    2, // bad: Concurrency > Requests
+				RequestTimeout: 1 * time.Second,
+				GlobalTimeout:  3 * time.Second,
+			},
+			)),
 			exp: dispatcher.ErrInvalidValue,
 		},
 	}
@@ -57,11 +58,11 @@ func TestRun(t *testing.T) {
 	}
 
 	t.Run("record failing requests", func(t *testing.T) {
-		r := withErrTransport(New(runnerConfig{
-			requests:       1,
-			concurrency:    1,
-			requestTimeout: 1 * time.Second,
-			globalTimeout:  3 * time.Second,
+		r := withErrTransport(New(Config{
+			Requests:       1,
+			Concurrency:    1,
+			RequestTimeout: 1 * time.Second,
+			GlobalTimeout:  3 * time.Second,
 		}))
 
 		rep, err := r.Run(validRequest())
@@ -85,11 +86,11 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("happy path", func(t *testing.T) {
-		r := withNoopTransport(New(runnerConfig{
-			requests:       1,
-			concurrency:    1,
-			requestTimeout: 1 * time.Second,
-			globalTimeout:  3 * time.Second,
+		r := withNoopTransport(New(Config{
+			Requests:       1,
+			Concurrency:    1,
+			RequestTimeout: 1 * time.Second,
+			GlobalTimeout:  3 * time.Second,
 		}))
 
 		rep, err := r.Run(validRequest())
@@ -134,11 +135,11 @@ func TestRun(t *testing.T) {
 			gotTimes = make([]time.Duration, 0, requests)
 		)
 
-		cfg := runnerConfig{
-			concurrency:   concurrency,
-			requests:      requests,
-			interval:      interval,
-			globalTimeout: 5 * time.Second,
+		cfg := Config{
+			Concurrency:   concurrency,
+			Requests:      requests,
+			Interval:      interval,
+			GlobalTimeout: 5 * time.Second,
 		}
 
 		r := withCallbackTransport(New(cfg), func() {
@@ -194,32 +195,6 @@ func TestRun(t *testing.T) {
 }
 
 // helpers
-
-// runnerConfig implements requester.Config
-type runnerConfig struct {
-	requests, concurrency                   int
-	interval, requestTimeout, globalTimeout time.Duration
-}
-
-func (cfg runnerConfig) Requests() int {
-	return cfg.requests
-}
-
-func (cfg runnerConfig) Concurrency() int {
-	return cfg.concurrency
-}
-
-func (cfg runnerConfig) Interval() time.Duration {
-	return cfg.interval
-}
-
-func (cfg runnerConfig) RequestTimeout() time.Duration {
-	return cfg.requestTimeout
-}
-
-func (cfg runnerConfig) GlobalTimeout() time.Duration {
-	return cfg.globalTimeout
-}
 
 type callbackTransport struct{ callback func() }
 

--- a/requester/requester_internal_test.go
+++ b/requester/requester_internal_test.go
@@ -28,13 +28,11 @@ func TestRun(t *testing.T) {
 		{
 			label: "return ErrRequest early on request error",
 			req: New(config.Config{
-				Request: config.Request{
-					Timeout: 0,
-				},
 				RunnerOptions: config.RunnerOptions{
-					Requests:      -1,
-					Concurrency:   1,
-					GlobalTimeout: 0,
+					Requests:       -1,
+					Concurrency:    1,
+					RequestTimeout: 1 * time.Second,
+					GlobalTimeout:  0,
 				},
 			}.WithURL(badURL)),
 			exp: ErrRequest,
@@ -42,13 +40,11 @@ func TestRun(t *testing.T) {
 		{
 			label: "return ErrConnection early on connection error",
 			req: New(config.Config{
-				Request: config.Request{
-					Timeout: 0,
-				},
 				RunnerOptions: config.RunnerOptions{
-					Requests:      -1,
-					Concurrency:   1,
-					GlobalTimeout: 0,
+					Requests:       -1,
+					Concurrency:    1,
+					RequestTimeout: 1 * time.Second,
+					GlobalTimeout:  0,
 				},
 			}.WithURL(goodURL)),
 			exp: ErrConnection,
@@ -56,13 +52,11 @@ func TestRun(t *testing.T) {
 		{
 			label: "return dispatcher.ErrInvalidValue early on bad dispatcher value",
 			req: withNoopTransport(New(config.Config{
-				Request: config.Request{
-					Timeout: time.Second,
-				},
 				RunnerOptions: config.RunnerOptions{
-					Requests:      1,
-					Concurrency:   2, // bad: Concurrency > Requests
-					GlobalTimeout: 3 * time.Second,
+					Requests:       1,
+					Concurrency:    2, // bad: Concurrency > Requests
+					RequestTimeout: 1 * time.Second,
+					GlobalTimeout:  3 * time.Second,
 				},
 			}.WithURL(goodURL))),
 			exp: dispatcher.ErrInvalidValue,
@@ -85,13 +79,11 @@ func TestRun(t *testing.T) {
 
 	t.Run("record failing requests", func(t *testing.T) {
 		r := withErrTransport(New(config.Config{
-			Request: config.Request{
-				Timeout: time.Second,
-			},
 			RunnerOptions: config.RunnerOptions{
-				Requests:      1,
-				Concurrency:   1,
-				GlobalTimeout: 3 * time.Second,
+				Requests:       1,
+				Concurrency:    1,
+				RequestTimeout: 1 * time.Second,
+				GlobalTimeout:  3 * time.Second,
 			},
 		}.WithURL(goodURL)))
 
@@ -117,13 +109,11 @@ func TestRun(t *testing.T) {
 
 	t.Run("happy path", func(t *testing.T) {
 		r := withNoopTransport(New(config.Config{
-			Request: config.Request{
-				Timeout: time.Second,
-			},
 			RunnerOptions: config.RunnerOptions{
-				Requests:      1,
-				Concurrency:   1,
-				GlobalTimeout: 3 * time.Second,
+				Requests:       1,
+				Concurrency:    1,
+				RequestTimeout: 1 * time.Second,
+				GlobalTimeout:  3 * time.Second,
 			},
 		}.WithURL(goodURL)))
 

--- a/requester/requester_internal_test.go
+++ b/requester/requester_internal_test.go
@@ -28,7 +28,7 @@ func TestRun(t *testing.T) {
 		{
 			label: "return ErrRequest early on request error",
 			req: New(config.Config{
-				RunnerOptions: config.RunnerOptions{
+				Runner: config.Runner{
 					Requests:       -1,
 					Concurrency:    1,
 					RequestTimeout: 1 * time.Second,
@@ -40,7 +40,7 @@ func TestRun(t *testing.T) {
 		{
 			label: "return ErrConnection early on connection error",
 			req: New(config.Config{
-				RunnerOptions: config.RunnerOptions{
+				Runner: config.Runner{
 					Requests:       -1,
 					Concurrency:    1,
 					RequestTimeout: 1 * time.Second,
@@ -52,7 +52,7 @@ func TestRun(t *testing.T) {
 		{
 			label: "return dispatcher.ErrInvalidValue early on bad dispatcher value",
 			req: withNoopTransport(New(config.Config{
-				RunnerOptions: config.RunnerOptions{
+				Runner: config.Runner{
 					Requests:       1,
 					Concurrency:    2, // bad: Concurrency > Requests
 					RequestTimeout: 1 * time.Second,
@@ -79,7 +79,7 @@ func TestRun(t *testing.T) {
 
 	t.Run("record failing requests", func(t *testing.T) {
 		r := withErrTransport(New(config.Config{
-			RunnerOptions: config.RunnerOptions{
+			Runner: config.Runner{
 				Requests:       1,
 				Concurrency:    1,
 				RequestTimeout: 1 * time.Second,
@@ -109,7 +109,7 @@ func TestRun(t *testing.T) {
 
 	t.Run("happy path", func(t *testing.T) {
 		r := withNoopTransport(New(config.Config{
-			RunnerOptions: config.RunnerOptions{
+			Runner: config.Runner{
 				Requests:       1,
 				Concurrency:    1,
 				RequestTimeout: 1 * time.Second,
@@ -160,7 +160,7 @@ func TestRun(t *testing.T) {
 		)
 
 		cfg := config.Config{
-			RunnerOptions: config.RunnerOptions{
+			Runner: config.Runner{
 				Concurrency:   concurrency,
 				Requests:      requests,
 				Interval:      interval,

--- a/test/testdata/config/badfields.json
+++ b/test/testdata/config/badfields.json
@@ -1,5 +1,5 @@
 {
-  "runnerOptions": {
+  "runner": {
     "requests": [123],
     "concurrency": "123"
   },

--- a/test/testdata/config/badfields.yml
+++ b/test/testdata/config/badfields.yml
@@ -1,4 +1,4 @@
-runnerOptions:
+runner:
   requests: [123] # error: invalid type for field requests
   concurrency: "123" # error: invalid type for field concurrency
 notafield: 123 # error: field does not exist

--- a/test/testdata/config/benchttp-zeros.yml
+++ b/test/testdata/config/benchttp-zeros.yml
@@ -1,3 +1,3 @@
-runnerOptions:
+runner:
   requests: 0
   globalTimeout: 42ms

--- a/test/testdata/config/benchttp.json
+++ b/test/testdata/config/benchttp.json
@@ -10,7 +10,7 @@
       "key1": ["val0"]
     }
   },
-  "runnerOptions": {
+  "runner": {
     "requests": 100,
     "concurrency": 1,
     "interval": "50ms",

--- a/test/testdata/config/benchttp.json
+++ b/test/testdata/config/benchttp.json
@@ -8,13 +8,13 @@
     "header": {
       "key0": ["val0", "val1"],
       "key1": ["val0"]
-    },
-    "timeout": "2s"
+    }
   },
   "runnerOptions": {
     "requests": 100,
     "concurrency": 1,
     "interval": "50ms",
+    "requestTimeout": "2s",
     "globalTimeout": "60s"
   }
 }

--- a/test/testdata/config/benchttp.yaml
+++ b/test/testdata/config/benchttp.yaml
@@ -9,10 +9,10 @@ request:
   header:
     key0: [val0, val1]
     key1: [val0]
-  timeout: 2s
 
 runnerOptions:
   requests: 100
   concurrency: 1
   interval: 50ms
+  requestTimeout: 2s
   globalTimeout: 60s

--- a/test/testdata/config/benchttp.yaml
+++ b/test/testdata/config/benchttp.yaml
@@ -10,7 +10,7 @@ request:
     key0: [val0, val1]
     key1: [val0]
 
-runnerOptions:
+runner:
   requests: 100
   concurrency: 1
   interval: 50ms

--- a/test/testdata/config/benchttp.yml
+++ b/test/testdata/config/benchttp.yml
@@ -6,10 +6,10 @@ request:
   header:
     key0: [val0, val1]
     key1: [val0]
-  timeout: 2s
 
 runnerOptions:
   requests: 100
   concurrency: 1
   interval: 50ms
+  requestTimeout: 2s
   globalTimeout: 60s

--- a/test/testdata/config/benchttp.yml
+++ b/test/testdata/config/benchttp.yml
@@ -7,7 +7,7 @@ request:
     key0: [val0, val1]
     key1: [val0]
 
-runnerOptions:
+runner:
   requests: 100
   concurrency: 1
   interval: 50ms


### PR DESCRIPTION
<!-- IMPORTANT: Don't forget to link the issue(s) once the PR created! -->

## Description

The goal of this PR is to reevaluate and refactor the config flow, especially regarding its use by `requester`.

Having a unique `config.Config` entity worked well until now, because it represented everything `requester` needs, and nothing more.
With the further implementations of output handling, this is not gonna be the case anymore.
Because `config.Config` is won't represent the config for `requester` anymore, we don't want `requester` to depend on it.

So here we remove all couplings between `requester` and `config`, so that `requester` becomes a fully independent module, as we did earlier with `dispatcher`.



<!--
    Describe briefly what this PR does, if the issue description is not enough.
    Add any information that could be relevant for the reviewers.
-->

## Changes

- Rename/Reorder:
  - `config.Config` ➡️  `config.Global`
  - `Config.RunnerOptions` ➡️  `config.Runner`
  - `Config.Request.Timeout` ➡️  `config.Runner.RequestTimeout`
  - `-timeout` ➡️  `-requestTimeout`
- Dependencies
  - `config` and `requester` fully uncoupled
  - `requester` accepts a `requester.Config` interface
  - `config.Global` implements `requester.Config`


<!-- Optional: mention here indirect changes impacted by the PR -->

## Notes

- 90f16702e5f651bdee2c8748fe0ae59e8fc8e86b`Uncouple packages config and requester` provides a solution to uncouple `config` and `requester` using an **interface** `requester.Config`. It's discussable API-wise, there's an alternative using a third package `internal/adapter` to handle the conversion (note: the conversion being trivial, the only purpose of this package is to keep both entities uncoupled). PR is here: #50 
  EDIT: Actually I think we should just drop that commit and that's it. The mentioned PR is basically the same thing as the preceeding commit, except the conversion is done in a separate package instead of main. A bit overkill given how trivial it is.

<!-- Optional: additional notes than can help understanding the implementation -->
