### PR TITLE
bug: huge trace

### DIFF
--- a/config/file/parser.go
+++ b/config/file/parser.go
@@ -128,7 +128,7 @@ func (p yamlParser) prettyErrorMessage(raw string) string {
 // jsonParser implements configParser.
 type jsonParser struct{}
 
-// parse decodes a raw json input in strict mode (unknown fields disallowed)
+// parse decodes a raw JSON input in strict mode (unknown fields disallowed)
 // and stores the resulting value into dst.
 func (p jsonParser) parse(in []byte, dst *unmarshaledConfig) error {
 	decoder := json.NewDecoder(bytes.NewReader(in))

--- a/requester/error.go
+++ b/requester/error.go
@@ -8,6 +8,4 @@ var (
 	ErrConnection = errors.New("connection error")
 	// ErrReporting is returned when the Requester fails to send the report.
 	ErrReporting = errors.New("reporting error")
-	// ErrRequestBody is returned when the Requester fails to get the body of the request to copy it
-	ErrRequestBody = errors.New("request body error")
 )

--- a/requester/httputil.go
+++ b/requester/httputil.go
@@ -1,0 +1,32 @@
+package requester
+
+import (
+	"io"
+	"net/http"
+	"time"
+)
+
+// newClient returns a new http.Client with the given transport and timeout.
+func newClient(transport http.RoundTripper, timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+	}
+}
+
+// cloneRequest fully clones a *http.Request by also cloning the body
+// via Request.GetBody.
+func cloneRequest(req *http.Request) *http.Request {
+	reqClone := req.Clone(req.Context())
+	if req.Body != nil {
+		// err is always nil (https://golang.org/src/net/http/request.go#L889)
+		reqClone.Body, _ = req.GetBody()
+	}
+	return reqClone
+}
+
+// readClose reads resp.Body and closes it.
+func readClose(resp *http.Response) ([]byte, error) {
+	defer resp.Body.Close()
+	return io.ReadAll(resp.Body)
+}

--- a/requester/print.go
+++ b/requester/print.go
@@ -10,6 +10,7 @@ import (
 	"github.com/benchttp/runner/ansi"
 )
 
+// state represents the progression of a benchmark at a given time.
 type state struct {
 	done             bool
 	err              error
@@ -17,6 +18,7 @@ type state struct {
 	timeout, elapsed time.Duration
 }
 
+// state returns the current state of the benchmark.
 func (r *Requester) state() state {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -30,6 +32,9 @@ func (r *Requester) state() state {
 	}
 }
 
+// String returns a string representation of state for a fancy display
+// in a CLI:
+// 	RUNNING ◼︎◼︎◼︎◼︎◼︎◼︎◼︎◼︎◼︎◼︎ 50% | 50/100 requests | 27s timeout
 func (s state) String() string {
 	var (
 		countdown = s.timeout - s.elapsed
@@ -47,7 +52,8 @@ func (s state) String() string {
 
 	return fmt.Sprintf(
 		"%s%s %s %d%% | %d/%s requests | %.0fs timeout             \n",
-		ansi.Erase(1), s.status(), timeline, pctdone, // progress
+		ansi.Erase(1),                 // replace previous line
+		s.status(), timeline, pctdone, // progress
 		s.reqcur, reqmax, // requests
 		countdown.Seconds(), // timeout
 	)
@@ -60,6 +66,8 @@ var (
 	tlLen        = 10
 )
 
+// timeline returns a colored representation of the progress as a string:
+// 	◼︎◼︎◼︎◼︎◼︎◼︎◼︎◼︎◼︎◼︎
 func (s state) timeline(pctdone int) string {
 	tl := strings.Repeat(tlBlockGrey, tlLen)
 	for i := 0; i < tlLen; i++ {
@@ -70,6 +78,8 @@ func (s state) timeline(pctdone int) string {
 	return tl
 }
 
+// status returns a string representing the status, depending on whether
+// the run is done or not and the value of the context error.
 func (s state) status() string {
 	if !s.done {
 		return ansi.Yellow("RUNNING")
@@ -85,6 +95,9 @@ func (s state) status() string {
 	return "" // should not occur
 }
 
+// percentDone returns the progression of the run as a percentage.
+// It is based on the ratio requests done / max requests if it's finite
+// (not -1), else on the ratio elapsed time / global timeout.
 func (s state) percentDone() int {
 	var cur, max int
 	if s.reqmax == -1 {
@@ -95,6 +108,7 @@ func (s state) percentDone() int {
 	return capInt((100*cur)/max, 100)
 }
 
+// capInt returns n if n <= max, max otherwise.
 func capInt(n, max int) int {
 	if n > max {
 		return max

--- a/requester/report.go
+++ b/requester/report.go
@@ -15,7 +15,7 @@ type Report struct {
 	Fail    int      `json:"fail"`
 }
 
-// String returns an indented json representation of the report.
+// String returns an indented JSON representation of the report.
 func (rep Report) String() string {
 	b, _ := json.MarshalIndent(rep, "", "  ")
 	return string(b)

--- a/requester/report.go
+++ b/requester/report.go
@@ -15,6 +15,7 @@ type Report struct {
 	Fail    int      `json:"fail"`
 }
 
+// String returns an indented json representation of the report.
 func (rep Report) String() string {
 	b, _ := json.MarshalIndent(rep, "", "  ")
 	return string(b)

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -3,7 +3,6 @@ package requester
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -183,29 +182,4 @@ func (r *Requester) end(runErr error) {
 
 func (r *Requester) printState() {
 	fmt.Print(r.state())
-}
-
-// newClient returns a new http.Client with the given transport and timeout.
-func newClient(transport http.RoundTripper, timeout time.Duration) *http.Client {
-	return &http.Client{
-		Timeout:   timeout,
-		Transport: transport,
-	}
-}
-
-// cloneRequest fully clones a *http.Request by also cloning the body
-// via Request.GetBody.
-func cloneRequest(req *http.Request) *http.Request {
-	reqClone := req.Clone(req.Context())
-	if req.Body != nil {
-		// err is always nil (https://golang.org/src/net/http/request.go#L889)
-		reqClone.Body, _ = req.GetBody()
-	}
-	return reqClone
-}
-
-// readClose reads r and closes it.
-func readClose(resp *http.Response) ([]byte, error) {
-	defer resp.Body.Close()
-	return io.ReadAll(resp.Body)
 }

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -86,10 +86,12 @@ func (r *Requester) Run(req *http.Request) (Report, error) {
 }
 
 func (r *Requester) ping(req *http.Request) error {
-	resp, err := newClient(r.newTransport(), r.config.RequestTimeout).Do(req)
+	client := newClient(r.newTransport(), r.config.RequestTimeout)
+	resp, err := client.Do(req)
 	if resp != nil {
 		resp.Body.Close()
 	}
+	client.CloseIdleConnections()
 	return err
 }
 

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -108,7 +108,7 @@ type Record struct {
 
 func (r *Requester) record(req *http.Request, interval time.Duration) func() {
 	return func() {
-		// We need new client and request instances each call to record
+		// We need new client and request instances each call to this function
 		// to make it safe for concurrent use.
 		client := newClient(r.newTransport(), r.config.RequestTimeout)
 		newReq := cloneRequest(req)

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -113,8 +113,6 @@ func (r *Requester) record(req *http.Request, interval time.Duration) func() {
 		client := newClient(r.newTransport(), r.config.RequestTimeout)
 		newReq := cloneRequest(req)
 
-		sent := time.Now()
-
 		// Send request
 		resp, err := client.Do(newReq)
 		if err != nil {
@@ -129,8 +127,6 @@ func (r *Requester) record(req *http.Request, interval time.Duration) func() {
 			return
 		}
 
-		duration := time.Since(sent)
-
 		// Retrieve tracer events and append BodyRead event
 		events := []Event{}
 		if reqtracer, ok := client.Transport.(*tracer); ok {
@@ -140,7 +136,7 @@ func (r *Requester) record(req *http.Request, interval time.Duration) func() {
 
 		r.appendRecord(Record{
 			Code:   resp.StatusCode,
-			Time:   duration,
+			Time:   eventsTotalTime(events),
 			Bytes:  len(body),
 			Events: events,
 		})

--- a/requester/requester_internal_test.go
+++ b/requester/requester_internal_test.go
@@ -205,7 +205,9 @@ func (t callbackTransport) RoundTrip(*http.Request) (*http.Response, error) {
 }
 
 func withCallbackTransport(req *Requester, callback func()) *Requester {
-	req.client.Transport = callbackTransport{callback: callback}
+	req.newTransport = func() http.RoundTripper {
+		return callbackTransport{callback: callback}
+	}
 	return req
 }
 
@@ -220,7 +222,9 @@ func (errTransport) RoundTrip(*http.Request) (*http.Response, error) {
 }
 
 func withErrTransport(req *Requester) *Requester {
-	req.client.Transport = errTransport{}
+	req.newTransport = func() http.RoundTripper {
+		return errTransport{}
+	}
 	return req
 }
 

--- a/requester/tracer.go
+++ b/requester/tracer.go
@@ -16,70 +16,86 @@ type Event struct {
 // tracer is a http.RoundTripper to be used as a http.Transport
 // that records the events of an outgoing HTTP request.
 type tracer struct {
-	start  time.Time
-	events []Event
+	start     time.Time
+	events    []Event
+	transport http.RoundTripper
 }
 
 // RoundTrip implements http.RoundTripper. It attaches the client trace
 // to the request context and calls http.DefaultTransport.RoundTrip
 // with the new created request.
-func (p *tracer) RoundTrip(r *http.Request) (*http.Response, error) {
-	ctx := httptrace.WithClientTrace(r.Context(), p.trace())
-	return http.DefaultTransport.RoundTrip(r.WithContext(ctx))
+func (t *tracer) RoundTrip(r *http.Request) (*http.Response, error) {
+	ctx := httptrace.WithClientTrace(r.Context(), t.trace())
+	return t.transport.RoundTrip(r.WithContext(ctx))
+}
+
+// CloseIdleConnections closes any connections on its http.Transport
+// which are sitting idle in a "keep-alive" state.
+//
+// If the tracer's Transport does not have a CloseIdleConnections method
+// then this method does nothing.
+func (t *tracer) CloseIdleConnections() {
+	type closeIdler interface{ CloseIdleConnections() }
+	if tr, ok := t.transport.(closeIdler); ok {
+		tr.CloseIdleConnections()
+	}
 }
 
 // trace returns a http.ClientTrace that timestamps and records the events
 // of an outgoing HTTP request.
-func (p *tracer) trace() *httptrace.ClientTrace {
+func (t *tracer) trace() *httptrace.ClientTrace {
 	return &httptrace.ClientTrace{
 		GetConn: func(string) {
-			p.start = time.Now()
-			p.addEvent("GetConn")
+			t.start = time.Now()
+			t.addEvent("GetConn")
 		},
 		DNSStart: func(httptrace.DNSStartInfo) {
-			p.addEvent("DNSStart")
+			t.addEvent("DNSStart")
 		},
 		DNSDone: func(httptrace.DNSDoneInfo) {
-			p.addEvent("DNSDone")
+			t.addEvent("DNSDone")
 		},
 		ConnectStart: func(string, string) {
-			p.addEvent("ConnectStart")
+			t.addEvent("ConnectStart")
 		},
 		ConnectDone: func(string, string, error) {
-			p.addEvent("ConnectDone")
+			t.addEvent("ConnectDone")
 		},
 		GotConn: func(httptrace.GotConnInfo) {
-			p.addEvent("GotConn")
+			t.addEvent("GotConn")
 		},
 		TLSHandshakeStart: func() {
-			p.addEvent("TLSHandshakeStart")
+			t.addEvent("TLSHandshakeStart")
 		},
 		TLSHandshakeDone: func(tls.ConnectionState, error) {
-			p.addEvent("TLSHandshakeDone")
+			t.addEvent("TLSHandshakeDone")
 		},
 
 		WroteHeaders: func() {
-			p.addEvent("WroteHeaders")
+			t.addEvent("WroteHeaders")
 		},
 		WroteRequest: func(httptrace.WroteRequestInfo) {
-			p.addEvent("WroteRequest")
+			t.addEvent("WroteRequest")
 		},
 		GotFirstResponseByte: func() {
-			p.addEvent("GotFirstResponseByte")
+			t.addEvent("GotFirstResponseByte")
 		},
 		PutIdleConn: func(error) {
-			p.addEvent("PutIdleConn")
+			t.addEvent("PutIdleConn")
 		},
 	}
 }
 
 // addEvent timestamps and appends and event to the tracer's events slice.
-func (p *tracer) addEvent(name string) {
-	p.events = append(p.events, Event{Name: name, Time: time.Since(p.start)})
+func (t *tracer) addEvent(name string) {
+	t.events = append(t.events, Event{Name: name, Time: time.Since(t.start)})
 }
 
 // newTracer returns an initialized tracer.
 func newTracer() *tracer {
-	p := &tracer{events: make([]Event, 0, 20)}
+	p := &tracer{
+		events:    make([]Event, 0, 20),
+		transport: http.DefaultTransport,
+	}
 	return p
 }

--- a/requester/tracer.go
+++ b/requester/tracer.go
@@ -78,6 +78,11 @@ func (t *tracer) addEvent(name string) {
 	t.events = append(t.events, Event{Name: name, Time: time.Since(t.start)})
 }
 
+// addEventBodyRead adds event BodyRead to the tracer's events slice.
+func (t *tracer) addEventBodyRead() {
+	t.addEvent("BodyRead")
+}
+
 // newTracer returns an initialized tracer.
 func newTracer() *tracer {
 	return &tracer{

--- a/requester/tracer.go
+++ b/requester/tracer.go
@@ -32,8 +32,9 @@ func (t *tracer) RoundTrip(r *http.Request) (*http.Response, error) {
 // CloseIdleConnections closes any connections on its http.Transport
 // which are sitting idle in a "keep-alive" state.
 //
-// If the tracer's Transport does not have a CloseIdleConnections method
-// then this method does nothing.
+// It provides access to the Tracer private Transport's CloseIdleConnections
+// method. If the Tracer's Transport does not have a CloseIdleConnections
+// method then this method does nothing.
 func (t *tracer) CloseIdleConnections() {
 	type closeIdler interface{ CloseIdleConnections() }
 	if tr, ok := t.transport.(closeIdler); ok {

--- a/requester/tracer.go
+++ b/requester/tracer.go
@@ -90,3 +90,10 @@ func newTracer() *tracer {
 		transport: http.DefaultTransport,
 	}
 }
+
+func eventsTotalTime(events []Event) time.Duration {
+	if len(events) == 0 {
+		return 0
+	}
+	return events[len(events)-1].Time
+}

--- a/requester/tracer.go
+++ b/requester/tracer.go
@@ -91,6 +91,8 @@ func newTracer() *tracer {
 	}
 }
 
+// eventsTotalTime returns the time of the last event, or 0
+// if events is empty.
 func eventsTotalTime(events []Event) time.Duration {
 	if len(events) == 0 {
 		return 0

--- a/requester/tracer_internal_test.go
+++ b/requester/tracer_internal_test.go
@@ -12,12 +12,8 @@ func TestTracer(t *testing.T) {
 		trace := tracer.trace()
 
 		trace.GetConn("")
-		trace.DNSStart(httptrace.DNSStartInfo{})
 		trace.DNSDone(httptrace.DNSDoneInfo{})
-		trace.ConnectStart("", "")
 		trace.ConnectDone("", "", nil)
-		trace.GotConn(httptrace.GotConnInfo{})
-		trace.TLSHandshakeStart()
 		trace.TLSHandshakeDone(tls.ConnectionState{}, nil)
 		trace.WroteHeaders()
 		trace.WroteRequest(httptrace.WroteRequestInfo{})
@@ -25,8 +21,7 @@ func TestTracer(t *testing.T) {
 		trace.PutIdleConn(nil)
 
 		expEventNames := []string{
-			"GetConn", "DNSStart", "DNSDone", "ConnectStart", "ConnectDone",
-			"GotConn", "TLSHandshakeStart", "TLSHandshakeDone", "WroteHeaders",
+			"DNSDone", "ConnectDone", "TLSHandshakeDone", "WroteHeaders",
 			"WroteRequest", "GotFirstResponseByte", "PutIdleConn",
 		}
 		gotEvents := tracer.events


### PR DESCRIPTION
<!-- IMPORTANT: Don't forget to link the issue(s) once the PR created! -->

## Description

The traces of different requests were mixed and duplicated across reports because we were using the same `*http.Client` with the same `tracer` as transport for all the requests. The accumulated trace was leading to reports of unacceptable length (200k lines and 4MB for 100 requests only).

This PR fixes that behaviour by renewing `*http.Client` and its transport each request: the same benchmarks now generates 4k lines and 70KB.

It also comes with some various improvements, see below.

<!--
    Describe briefly what this PR does, if the issue description is not enough.
    Add any information that could be relevant for the reviewers.
-->

## Changes

- Do not handle `request.GetBody` error: it is always `nil` by design when created via `http.Request` (which we do). We might want to add a unit test to unsure we always do. 
- Trace events:
  - Remove superfluous events `GetConn`,  `ConnectStart`, `TLSHandshakeStart`, `GotConn`
  - Add new custom event `BodyRead` after the body is read
- Determine request duration using the last event instead of calls to `time` in the callback

<!-- Optional: mention here indirect changes impacted by the PR -->

## Notes

<!-- Optional: additional notes than can help understanding the implementation -->
