### PR TITLE
feat: handle graceful shutdown on os.Interrupt

### DIFF
--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"bufio"
+	"context"
 	"errors"
 	"flag"
 	"fmt"
-	"log"
 	"net/http"
+	"os"
+	"os/signal"
 	"strings"
 	"time"
 
@@ -77,7 +80,8 @@ func parseArgs() {
 
 func main() {
 	if err := run(); err != nil {
-		log.Fatal(err)
+		fmt.Println(err)
+		os.Exit(1)
 	}
 }
 
@@ -94,9 +98,18 @@ func run() error {
 		return err
 	}
 
-	rep, err := requester.New(requesterConfig(cfg)).Run(req)
+	ctx, cancel := context.WithCancel(context.Background())
+	go listenOSInterrupt(cancel)
+
+	rep, err := requester.New(requesterConfig(cfg)).Run(ctx, req)
 	if err != nil {
-		return err
+		if errors.Is(err, requester.ErrCanceled) {
+			if err := handleRunInterrupt(); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
 	}
 
 	return output.New(rep, cfg).Export()
@@ -246,6 +259,33 @@ func (v outValue) Set(in string) error {
 	}
 	for _, value := range values {
 		*v.out = append(*v.out, config.OutputStrategy(value))
+	}
+	return nil
+}
+
+// listenOSInterrupt listens for OS interrupt signals and calls callback.
+// It should be called in a separate goroutine from main as it blocks
+// the execution until the OS interrupt signal is received.
+func listenOSInterrupt(callback func()) {
+	sigC := make(chan os.Signal, 1)
+	signal.Notify(sigC, os.Interrupt)
+	<-sigC
+	callback()
+}
+
+// handleRunInterrupt handles the case when the runner is interrupted.
+func handleRunInterrupt() error {
+	reader := bufio.NewReader(os.Stdin)
+	// TODO: list output strategies
+	// TODO: do not prompt if strategy is stdout only
+	// TODO: add config option "output.generateOnCancel" and remove prompt?
+	fmt.Printf("\nBenchmark interrupted, generate output anyway? (yes/no): ")
+	line, _, err := reader.ReadLine()
+	if err != nil {
+		return err
+	}
+	if string(line) != "yes" {
+		return errors.New("benchmark interrupted without output")
 	}
 	return nil
 }

--- a/requester/error.go
+++ b/requester/error.go
@@ -8,4 +8,6 @@ var (
 	ErrConnection = errors.New("connection error")
 	// ErrReporting is returned when the Requester fails to send the report.
 	ErrReporting = errors.New("reporting error")
+	// ErrCanceled is returned when the Requester.Run context is canceled.
+	ErrCanceled = errors.New("canceled")
 )

--- a/requester/print.go
+++ b/requester/print.go
@@ -88,7 +88,7 @@ func (s state) status() string {
 	case nil:
 		return ansi.Green("DONE")
 	case context.Canceled:
-		return ansi.Cyan("CANCELED")
+		return ansi.Red("CANCELED")
 	case context.DeadlineExceeded:
 		return ansi.Cyan("TIMEOUT")
 	}

--- a/requester/requester_internal_test.go
+++ b/requester/requester_internal_test.go
@@ -2,6 +2,7 @@ package requester
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"net/http"
 	"reflect"
@@ -46,7 +47,7 @@ func TestRun(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.label, func(t *testing.T) {
-			gotRep, gotErr := tc.req.Run(validRequest())
+			gotRep, gotErr := tc.req.Run(context.Background(), validRequest())
 
 			if !errors.Is(gotErr, tc.exp) {
 				t.Errorf("unexpected error value:\nexp %v\ngot %v", tc.exp, gotErr)
@@ -66,7 +67,7 @@ func TestRun(t *testing.T) {
 			GlobalTimeout:  3 * time.Second,
 		}))
 
-		rep, err := r.Run(validRequest())
+		rep, err := r.Run(context.Background(), validRequest())
 		if err != nil {
 			t.Errorf("exp nil error, got %v", err)
 		}
@@ -94,7 +95,10 @@ func TestRun(t *testing.T) {
 			GlobalTimeout:  3 * time.Second,
 		}))
 
-		rep, err := r.Run(validRequestWithBody([]byte(`{"key0": "val0", "key1": "val1"}`)))
+		rep, err := r.Run(
+			context.Background(),
+			validRequestWithBody([]byte(`{"key0": "val0", "key1": "val1"}`)),
+		)
 		if err != nil {
 			t.Errorf("exp nil error, got %v", err)
 		}
@@ -164,7 +168,7 @@ func TestRun(t *testing.T) {
 			gotTimes = append(gotTimes, elapsed)
 		})
 
-		if _, err := r.Run(validRequest()); err != nil {
+		if _, err := r.Run(context.Background(), validRequest()); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 


### PR DESCRIPTION
<!-- IMPORTANT: Don't forget to link the issue(s) once the PR created! -->

## Description

On os.Interrupt (`ctrl+c`), we prompt the user to determine what to do with the current run results.

### Demo

![benchttp-graceful-shutdown](https://user-images.githubusercontent.com/60700958/154795684-2ba8135a-2535-4f8b-99b4-9e58e3081dc6.gif)


<!--

    Describe briefly what this PR does, if the issue description is not enough.
    Add any information that could be relevant for the reviewers.
-->

## Changes

- Updated `Requester.Run` signature to accept a context
- Changed status color for "CANCELED" from cyan to red

<!-- Optional: mention here indirect changes impacted by the PR -->

## Notes

<!-- Optional: additional notes than can help understanding the implementation -->
