### PR TITLE
fix: typo "stdout" as "stdin" in error messages

### DIFF
--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -36,7 +36,7 @@ var (
 	requestTimeout time.Duration // Timeout for each HTTP request
 	globalTimeout  time.Duration // Duration of test
 
-	out      []config.OutputStrategy // Output destinations (benchttp,json,stdin)
+	out      []config.OutputStrategy // Output destinations (benchttp,json,stdout)
 	silent   bool                    // Silent mode (no write to stdout)
 	template string
 )
@@ -72,7 +72,7 @@ func parseArgs() {
 	flag.DurationVar(&globalTimeout, config.FieldGlobalTimeout, 0, "Max duration of test")
 
 	// output strategies
-	flag.Var(outValue{out: &out}, config.FieldOut, "Output destination (benchttp,json,stdin)")
+	flag.Var(outValue{out: &out}, config.FieldOut, "Output destination (benchttp,json,stdout)")
 	// silent mode
 	flag.BoolVar(&silent, config.FieldSilent, false, "Silent mode (no write to stdout)")
 	// output template

--- a/config/config.go
+++ b/config/config.go
@@ -183,12 +183,12 @@ func (cfg Global) Validate() error { //nolint:gocognit
 	}
 
 	if out := cfg.Output.Out; len(out) == 0 {
-		appendError(errors.New(`-out: missing (want one or many of "benchttp", "json", "stdin")`))
+		appendError(errors.New(`-out: missing (want one or many of "benchttp", "json", "stdout")`))
 	} else {
 		for _, o := range out {
 			if !IsOutput(string(o)) {
 				appendError(fmt.Errorf(
-					`-out: invalid value: %s (want one or many of "benchttp", "json", "stdin")`, o),
+					`-out: invalid value: %s (want one or many of "benchttp", "json", "stdout")`, o),
 				)
 			}
 		}

--- a/config/file/parse_test.go
+++ b/config/file/parse_test.go
@@ -154,7 +154,7 @@ func newExpConfig() config.Global {
 			GlobalTimeout:  60 * time.Second,
 		},
 		Output: config.Output{
-			Out:      []config.OutputStrategy{"benchttp", "json", "stdin"},
+			Out:      []config.OutputStrategy{"benchttp", "json", "stdout"},
 			Silent:   true,
 			Template: "{{ .Report.Length }}",
 		},

--- a/test/testdata/config/benchttp.json
+++ b/test/testdata/config/benchttp.json
@@ -22,7 +22,7 @@
     "globalTimeout": "60s"
   },
   "output": {
-    "out": ["benchttp", "json", "stdin"],
+    "out": ["benchttp", "json", "stdout"],
     "silent": true,
     "template": "{{ .Report.Length }}"
   }

--- a/test/testdata/config/benchttp.yaml
+++ b/test/testdata/config/benchttp.yaml
@@ -24,6 +24,6 @@ output:
   out:
     - benchttp
     - json
-    - stdin
+    - stdout
   silent: true
   template: "{{ .Report.Length }}"

--- a/test/testdata/config/benchttp.yml
+++ b/test/testdata/config/benchttp.yml
@@ -21,6 +21,6 @@ output:
   out:
     - benchttp
     - json
-    - stdin
+    - stdout
   silent: true
   template: "{{ .Report.Length }}"


### PR DESCRIPTION
<!-- IMPORTANT: Don't forget to link the issue(s) once the PR created! -->

## Description

```sh
./bin/benchttp -out stdin # correctly invalid, want "stdout"

Invalid value(s) provided:
# incorrectly reports the error, want "stdout"
-out: invalid value: stdin (want one or many of "benchttp", "json", "stdin")
```

Functionality is valid, only error message and some docs were wrongly worded.

## Changes

<!-- Optional: mention here indirect changes impacted by the PR -->

## Notes

<!-- Optional: additional notes than can help understanding the implementation -->
