### PR TITLE
refactor: record error as string

### DIFF
--- a/requester/error.go
+++ b/requester/error.go
@@ -1,6 +1,9 @@
 package requester
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var (
 	// ErrConnection is returned when the Requester fails to connect to
@@ -11,3 +14,9 @@ var (
 	// ErrCanceled is returned when the Requester.Run context is canceled.
 	ErrCanceled = errors.New("canceled")
 )
+
+// recordErr wraps and returns err as a string, marking it as an error
+// that happened when recording the request.
+func recordErr(err error) string {
+	return fmt.Sprintf("recording error: %s", err)
+}

--- a/requester/error.go
+++ b/requester/error.go
@@ -9,8 +9,6 @@ var (
 	// ErrConnection is returned when the Requester fails to connect to
 	// the requested URL.
 	ErrConnection = errors.New("connection error")
-	// ErrReporting is returned when the Requester fails to send the report.
-	ErrReporting = errors.New("reporting error")
 	// ErrCanceled is returned when the Requester.Run context is canceled.
 	ErrCanceled = errors.New("canceled")
 )


### PR DESCRIPTION
<!-- IMPORTANT: Don't forget to link the issue(s) once the PR created! -->

## Description

cloud.google.com/go/firestore does not handle `error` type when writing to/reading from Firestore.

As we use `gob` to pass data from runner to server, the structs must be defined exactly the same (is there a way around that?). Thus this change.

## Changes

Replace `error` with `string`, using empty string `""` would work the same as `nil` previously.

<!-- Optional: mention here indirect changes impacted by the PR -->

## Notes

<!-- Optional: additional notes than can help understanding the implementation -->
