### PR TITLE
fix(config): invalidate config if concurrency > requests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -151,7 +151,6 @@ func (cfg *Global) overrideHeader(newHeader http.Header) {
 // Validate returns the config and a not nil ErrInvalid if any of the fields provided by the user is not valid
 func (cfg Global) Validate() error { //nolint:gocognit
 	inputErrors := []error{}
-
 	appendError := func(err error) {
 		inputErrors = append(inputErrors, err)
 	}
@@ -166,8 +165,11 @@ func (cfg Global) Validate() error { //nolint:gocognit
 		appendError(fmt.Errorf("-requests: must be >= 0, we got %d", cfg.Runner.Requests))
 	}
 
-	if cfg.Runner.Concurrency < 1 && cfg.Runner.Concurrency != -1 {
-		appendError(fmt.Errorf("-concurrency: must be > 0, we got %d", cfg.Runner.Concurrency))
+	if cfg.Runner.Concurrency < 1 || cfg.Runner.Concurrency > cfg.Runner.Requests {
+		appendError(fmt.Errorf(
+			"-concurrency: must be > 0 and <= requests (%d), we got %d",
+			cfg.Runner.Requests, cfg.Runner.Concurrency,
+		))
 	}
 
 	if cfg.Runner.Interval < 0 {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -57,7 +57,7 @@ func TestValidate(t *testing.T) {
 			if !errorContains(err, "-requests: must be >= 0, we got ") {
 				t.Errorf("\n- information about invalid requests number missing from error message")
 			}
-			if !errorContains(err, "-concurrency: must be > 0, we got ") {
+			if !errorContains(err, "-concurrency: must be > 0 and <= requests") {
 				t.Errorf("\n- information about invalid concurrency number missing from error message")
 			}
 			if !errorContains(err, "-timeout: must be > 0, we got") {


### PR DESCRIPTION
<!-- IMPORTANT: Don't forget to link the issue(s) once the PR created! -->

## Description

We weren't checking `cfg.Runner.Concurrency <= cfg.Runner.Requests` in `cfg.Validate`.
As a consequence we were displaying an obscur error message for the user (from `dispatcher`):

```sh
go run ./cmd/benchttp run -requests 1 -concurrency 2 -url http://a.b.com
# output:
# invalid value: maxIter: must be >= numWorker (2), got 1
```

This PR fixes it. New error message:

```sh
go run ./cmd/benchttp run -requests 1 -concurrency 2 -url http://a.b.com
# output:
# Invalid value(s) provided:
# -concurrency: must be > 0 and <= requests (1), we got 2
```

<!--
    Describe briefly what this PR does, if the issue description is not enough.
    Add any information that could be relevant for the reviewers.
-->

## Changes

<!-- Optional: mention here indirect changes impacted by the PR -->

## Notes

<!-- Optional: additional notes than can help understanding the implementation -->
