### PR TITLE
feat(template): expose basic stats

### DIFF
--- a/output/report.go
+++ b/output/report.go
@@ -60,7 +60,7 @@ func newLogger(silent bool) *log.Logger {
 // Export exports the Report using the Strategies set in the embedded
 // config.Global. If any error occurs for a given Strategy, it does not
 // block the other exports and returns an ExportError listing the errors.
-func (rep Report) Export() error {
+func (rep *Report) Export() error {
 	var ok bool
 	var errs []error
 
@@ -103,7 +103,7 @@ func (rep Report) Export() error {
 var _ export.Interface = (*Report)(nil)
 
 // String returns a default summary of the Report as a string.
-func (rep Report) String() string {
+func (rep *Report) String() string {
 	var b strings.Builder
 
 	s, err := rep.applyTemplate(rep.Metadata.Config.Output.Template)
@@ -158,7 +158,7 @@ func (rep Report) String() string {
 // the result as a string. If pattern == "", it returns errTemplateEmpty.
 // If an error occurs parsing the pattern or executing the template,
 // it returns errTemplateSyntax.
-func (rep Report) applyTemplate(pattern string) (string, error) {
+func (rep *Report) applyTemplate(pattern string) (string, error) {
 	if pattern == "" {
 		return "", errTemplateEmpty
 	}
@@ -178,7 +178,7 @@ func (rep Report) applyTemplate(pattern string) (string, error) {
 
 // HTTPRequest returns the *http.Request to be sent to Benchttp server.
 // The Report is encoded as gob in the request body.
-func (rep Report) HTTPRequest() (*http.Request, error) {
+func (rep *Report) HTTPRequest() (*http.Request, error) {
 	// Encode request body as gob
 	b, err := encodeGob(rep)
 	if err != nil {
@@ -197,7 +197,7 @@ func (rep Report) HTTPRequest() (*http.Request, error) {
 // helpers
 
 // encodeGob encodes the given Report as gob-encoded bytes.
-func encodeGob(rep Report) ([]byte, error) {
+func encodeGob(rep *Report) ([]byte, error) {
 	var buf bytes.Buffer
 	if err := gob.NewEncoder(&buf).Encode(rep); err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- IMPORTANT: Don't forget to link the issue(s) once the PR created! -->

## Description

Expose a template func `stats` that provides access to basic stats computed on the go.
Stats are not computed if not explicitly called, and are always computed at most once.

### Examples

- Simple call
  ```yml
  output:
    template: '{{ stats.Min }}'
  ```
- Multiple calls (computation done only once)
  ```yml
  output:
    template: |
      Min: {{ stats.Min }}
      Max: {{ stats.Max }}
      Mean: {{ stats.Mean }}
  ```

<!--
    Describe briefly what this PR does, if the issue description is not enough.
    Add any information that could be relevant for the reviewers.
-->

## Changes

<!-- Optional: mention here indirect changes impacted by the PR -->

## Notes

<!-- Optional: additional notes than can help understanding the implementation -->
