### PR TITLE
feat(template): events by name

### DIFF
--- a/output/report.go
+++ b/output/report.go
@@ -197,6 +197,15 @@ func (rep *Report) templateFuncs() template.FuncMap {
 			}
 			return rep.stats
 		},
+
+		"event": func(rec requester.Record, name string) time.Duration {
+			for _, e := range rec.Events {
+				if e.Name == name {
+					return e.Time
+				}
+			}
+			return 0
+		},
 	}
 }
 


### PR DESCRIPTION
⚠️ Merge **after** #86 

<!-- IMPORTANT: Don't forget to link the issue(s) once the PR created! -->

## Description

Expose a template function `event` to access a record's request event by name.

### Usage example

- Display time of event "GotFirstResponseByte" for first record
  ```yml
  output:
    template: |
      {{- $rec0 := (index .Benchmark.Records 0) -}}
      {{ event $rec0 "GotFirstResponseByte" }}
  ```
- Display "FAIL" message for record with TTFB > 205ms
  ```yml
  output:
    template: |
      {{ range .Benchmark.Records -}}
        {{ $ttfb := (event . "GotFirstResponseByte").Milliseconds -}}
        {{ if ge $ttfb 205 }}FAIL: {{ $ttfb }}ms{{ end -}}
      {{ end -}}
  ```

<!--
    Describe briefly what this PR does, if the issue description is not enough.
    Add any information that could be relevant for the reviewers.
-->

## Changes

<!-- Optional: mention here indirect changes impacted by the PR -->

## Notes

<!-- Optional: additional notes than can help understanding the implementation -->
