### PR TITLE
feat(template): implement fail function

### DIFF
--- a/output/error.go
+++ b/output/error.go
@@ -9,6 +9,10 @@ var (
 	// ErrInvalidStrategy reports an unknown strategy set.
 	ErrInvalidStrategy = errors.New("invalid strategy")
 
+	// ErrTplFailTriggered a fail triggered by a user using the function
+	// {{ fail }} in an output template.
+	ErrTplFailTriggered = errors.New("test failed")
+
 	errTemplateEmpty  = errors.New("empty template")
 	errTemplateSyntax = errors.New("template syntax error")
 )

--- a/output/report.go
+++ b/output/report.go
@@ -38,6 +38,8 @@ type Report struct {
 
 	stats basicStats
 
+	errTplFailTriggered error
+
 	log func(v ...interface{})
 }
 
@@ -105,7 +107,7 @@ func (rep *Report) Export() error {
 	if len(errs) != 0 {
 		return &ExportError{Errors: errs}
 	}
-	return nil
+	return rep.errTplFailTriggered
 }
 
 // export.Interface implementation
@@ -205,6 +207,16 @@ func (rep *Report) templateFuncs() template.FuncMap {
 				}
 			}
 			return 0
+		},
+
+		"fail": func(a ...interface{}) string {
+			if rep.errTplFailTriggered == nil {
+				rep.errTplFailTriggered = fmt.Errorf(
+					"%w: %s",
+					ErrTplFailTriggered, fmt.Sprint(a...),
+				)
+			}
+			return ""
 		},
 	}
 }

--- a/output/template.go
+++ b/output/template.go
@@ -34,8 +34,12 @@ func (rep *Report) applyTemplate(pattern string) (string, error) {
 	return b.String(), nil
 }
 
+// templateFuncs returns a template.FuncMap defining template functions
+// that are specific to the Report: stats, event, fail.
 func (rep *Report) templateFuncs() template.FuncMap {
 	return template.FuncMap{
+		// stats computes basic stats for the Report if not already done,
+		// and returns the results as basicStats.
 		"stats": func() basicStats {
 			if rep.stats.isZero() {
 				rep.stats.Min, rep.stats.Max, rep.stats.Mean = rep.Benchmark.Stats()
@@ -43,6 +47,8 @@ func (rep *Report) templateFuncs() template.FuncMap {
 			return rep.stats
 		},
 
+		// event retrieves an event from the input record given a its name
+		// and returns its time.
 		"event": func(rec requester.Record, name string) time.Duration {
 			for _, e := range rec.Events {
 				if e.Name == name {
@@ -52,6 +58,8 @@ func (rep *Report) templateFuncs() template.FuncMap {
 			return 0
 		},
 
+		// fail sets rep.errTplFailTriggered to the given error, causing
+		// the test to fail
 		"fail": func(a ...interface{}) string {
 			if rep.errTplFailTriggered == nil {
 				rep.errTplFailTriggered = fmt.Errorf(

--- a/output/template.go
+++ b/output/template.go
@@ -1,0 +1,65 @@
+package output
+
+import (
+	"fmt"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/benchttp/runner/requester"
+)
+
+// applyTemplate applies Report to a template using given pattern and returns
+// the result as a string. If pattern == "", it returns errTemplateEmpty.
+// If an error occurs parsing the pattern or executing the template,
+// it returns errTemplateSyntax.
+func (rep *Report) applyTemplate(pattern string) (string, error) {
+	if pattern == "" {
+		return "", errTemplateEmpty
+	}
+
+	t, err := template.
+		New("report").
+		Funcs(rep.templateFuncs()).
+		Parse(pattern)
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", errTemplateSyntax, err)
+	}
+
+	var b strings.Builder
+	if err := t.Execute(&b, rep); err != nil {
+		return "", fmt.Errorf("%w: %s", errTemplateSyntax, err)
+	}
+
+	return b.String(), nil
+}
+
+func (rep *Report) templateFuncs() template.FuncMap {
+	return template.FuncMap{
+		"stats": func() basicStats {
+			if rep.stats.isZero() {
+				rep.stats.Min, rep.stats.Max, rep.stats.Mean = rep.Benchmark.Stats()
+			}
+			return rep.stats
+		},
+
+		"event": func(rec requester.Record, name string) time.Duration {
+			for _, e := range rec.Events {
+				if e.Name == name {
+					return e.Time
+				}
+			}
+			return 0
+		},
+
+		"fail": func(a ...interface{}) string {
+			if rep.errTplFailTriggered == nil {
+				rep.errTplFailTriggered = fmt.Errorf(
+					"%w: %s",
+					ErrTplFailTriggered, fmt.Sprint(a...),
+				)
+			}
+			return ""
+		},
+	}
+}


### PR DESCRIPTION
⚠️ Merge **after** #87 

<!-- IMPORTANT: Don't forget to link the issue(s) once the PR created! -->

## Description

Expose template function `fail` that fails the test with `os.Exit(1)` and a given message when called in a template.

### Usage example

Fail if max duration > 200ms

#### Template

```yml
output:
  template: |
    {{- if ge stats.Max.Milliseconds 200 -}}
      {{ fail "TOO SLOW" }}
    {{- else -}}
      OK
    {{- end -}}
```

#### Passing test

```sh
go run ./cmd/benchttp run -url "http://localhost:9999?delay=100ms"

# Output:
# OK
```

#### Failing test

```sh
go run ./cmd/benchttp run -url "http://localhost:9999?delay=300ms"

# Output:
# test failed: TOO SLOW
# exit status 1
```

<!--
    Describe briefly what this PR does, if the issue description is not enough.
    Add any information that could be relevant for the reviewers.
-->

## Changes

<!-- Optional: mention here indirect changes impacted by the PR -->

## Notes

<!-- Optional: additional notes than can help understanding the implementation -->
